### PR TITLE
Adding advanced scripted algorithm initialization

### DIFF
--- a/Parameters/AdaptiveAlgorithm/Scripted/IScriptedAlgorithmQuerier.cs
+++ b/Parameters/AdaptiveAlgorithm/Scripted/IScriptedAlgorithmQuerier.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BGC.Parameters.Algorithms.Scripted
+{
+    public interface IScriptedAlgorithmQuerier
+    {
+        bool CouldStepTo(int stepNumber);
+        bool CouldStepBy(int steps);
+    }
+
+    public interface IMultiParamScriptedAlgorithmQuerier
+    {
+        int GetParamCount();
+        bool CouldStepTo(int parameter, int stepNumber);
+        bool CouldStepBy(int parameter, int steps);
+    }
+}

--- a/Parameters/AdaptiveAlgorithm/Scripted/IScriptedAlgorithmQuerier.cs.meta
+++ b/Parameters/AdaptiveAlgorithm/Scripted/IScriptedAlgorithmQuerier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c859bae7046b91d4cbc50680df4bac01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Parameters/ControlledParameters/ControlledStringParameterTemplate.cs
+++ b/Parameters/ControlledParameters/ControlledStringParameterTemplate.cs
@@ -253,7 +253,7 @@ void Initialize() { }
 //Determine the value
 string GetValue(int stepNumber)
 {
-    return stimuli[stepNumber];
+    return stimuli[Math.Clamp(stepNumber, 0, stimuli.Count - 1)];
 }
 
 //Determine if the stepNumber would be valid

--- a/Parameters/ControlledParameters/ScriptedDoubleSteps.cs
+++ b/Parameters/ControlledParameters/ScriptedDoubleSteps.cs
@@ -228,7 +228,7 @@ void Initialize() { }
 //Determine the value to step to
 double GetValue(int stepNumber)
 {
-    return baseValue + stepSize * stepNumber;
+    return Math.Clamp(baseValue + stepSize * stepNumber, minValue, maxValue);
 }
 
 //Determine if the stepNumber would be valid

--- a/Parameters/ControlledParameters/ScriptedIntSteps.cs
+++ b/Parameters/ControlledParameters/ScriptedIntSteps.cs
@@ -229,7 +229,7 @@ void Initialize() { }
 //Determine the value to step to
 int GetValue(int stepNumber)
 {
-    return baseValue + stepSize * stepNumber;
+    return Math.Clamp(baseValue + stepSize * stepNumber, minValue, maxValue);
 }
 
 //Determine if the stepNumber would be valid

--- a/Parameters/ControlledParameters/SimpleDoubleListSteps.cs
+++ b/Parameters/ControlledParameters/SimpleDoubleListSteps.cs
@@ -17,7 +17,8 @@ namespace BGC.Parameters
 
         private static readonly char[] separators = new char[] { ',', ' ', '\n', '\r' };
 
-        double ISimpleDoubleStepTemplate.GetValue(int stepNumber) => values[stepNumber];
+        double ISimpleDoubleStepTemplate.GetValue(int stepNumber) =>
+            values[GeneralMath.Clamp(stepNumber, 0, values.Length - 1)];
 
         double ISimpleDoubleStepTemplate.GetPartialValue(double stepNumber) =>
             values[(int)Math.Round(GeneralMath.Clamp(stepNumber, 0, values.Length - 1))];

--- a/Parameters/ControlledParameters/SimpleIntListSteps.cs
+++ b/Parameters/ControlledParameters/SimpleIntListSteps.cs
@@ -17,7 +17,8 @@ namespace BGC.Parameters
 
         private static readonly char[] separators = new char[] { ',', ' ', '\n', '\r' };
 
-        int ISimpleIntStepTemplate.GetValue(int stepNumber) => values[stepNumber];
+        int ISimpleIntStepTemplate.GetValue(int stepNumber) =>
+            values[GeneralMath.Clamp(stepNumber, 0, values.Length - 1)];
 
         double ISimpleIntStepTemplate.GetPartialValue(double stepNumber) =>
             values[(int)Math.Round(GeneralMath.Clamp(stepNumber, 0, values.Length - 1))];

--- a/Scripting/Members/MemberManagement.cs
+++ b/Scripting/Members/MemberManagement.cs
@@ -8,6 +8,7 @@ using BGC.Users;
 using BGC.DataStructures.Generic;
 using BGC.UI.Dialogs;
 using BGC.Reports;
+using BGC.Parameters.Algorithms.Scripted;
 
 namespace BGC.Scripting
 {
@@ -999,6 +1000,67 @@ namespace BGC.Scripting
                             value: value,
                             operation: (DataFile dataFile) =>
                                 dataFile.Save(),
+                            source: source);
+
+                    default:
+                        throw new ScriptParsingException(
+                            source: source,
+                            message: $"Unable to identify {valueType.Name} member {identifier}");
+                }
+            }
+            else if (typeof(IScriptedAlgorithmQuerier).IsAssignableFrom(valueType))
+            {
+                switch (identifier)
+                {
+                    case "CouldStepTo":
+                        args.VerifyArgs(typeof(int), source, identifier);
+                        return new MemberArgumentValueOperation<IScriptedAlgorithmQuerier, bool>(
+                            value: value,
+                            operation: (IScriptedAlgorithmQuerier input, RuntimeContext context) =>
+                                input.CouldStepTo(args[0].GetAs<int>(context)),
+                            source: source);
+
+                    case "CouldStepBy":
+                        args.VerifyArgs(typeof(int), source, identifier);
+                        return new MemberArgumentValueOperation<IScriptedAlgorithmQuerier, bool>(
+                            value: value,
+                            operation: (IScriptedAlgorithmQuerier input, RuntimeContext context) =>
+                                input.CouldStepBy(args[0].GetAs<int>(context)),
+                            source: source);
+
+
+                    default:
+                        throw new ScriptParsingException(
+                            source: source,
+                            message: $"Unable to identify {valueType.Name} member {identifier}");
+                }
+            }
+            else if (typeof(IMultiParamScriptedAlgorithmQuerier).IsAssignableFrom(valueType))
+            {
+                switch (identifier)
+                {
+                    case "GetParamCount":
+                        args.VerifyArgs(source, identifier);
+                        return new MemberArgumentValueOperation<IMultiParamScriptedAlgorithmQuerier, int>(
+                            value: value,
+                            operation: (IMultiParamScriptedAlgorithmQuerier input, RuntimeContext context) =>
+                                input.GetParamCount(),
+                            source: source);
+
+                    case "CouldStepTo":
+                        args.VerifyArgs(typeof(int), typeof(int), source, identifier);
+                        return new MemberArgumentValueOperation<IMultiParamScriptedAlgorithmQuerier, bool>(
+                            value: value,
+                            operation: (IMultiParamScriptedAlgorithmQuerier input, RuntimeContext context) =>
+                                input.CouldStepTo(args[0].GetAs<int>(context), args[1].GetAs<int>(context)),
+                            source: source);
+
+                    case "CouldStepBy":
+                        args.VerifyArgs(typeof(int), typeof(int), source, identifier);
+                        return new MemberArgumentValueOperation<IMultiParamScriptedAlgorithmQuerier, bool>(
+                            value: value,
+                            operation: (IMultiParamScriptedAlgorithmQuerier input, RuntimeContext context) =>
+                                input.CouldStepBy(args[0].GetAs<int>(context), args[1].GetAs<int>(context)),
                             source: source);
 
                     default:

--- a/Scripting/Parsing/ScriptReader.cs
+++ b/Scripting/Parsing/ScriptReader.cs
@@ -432,6 +432,8 @@ namespace BGC.Scripting
                 //Other Types
                 case "Random": return new KeywordToken(line, startingColumn, Keyword.Random);
                 case "DataFile": return new KeywordToken(line, startingColumn, Keyword.DataFile);
+                case "IScriptedAlgorithmQuerier": return new KeywordToken(line, startingColumn, Keyword.IScriptedAlgorithmQuerier);
+                case "IMultiParamScriptedAlgorithmQuerier": return new KeywordToken(line, startingColumn, Keyword.IMultiParamScriptedAlgorithmQuerier);
 
                 //Static Types
                 case "System": return new KeywordToken(line, startingColumn, Keyword.System);

--- a/Scripting/Script.cs
+++ b/Scripting/Script.cs
@@ -5,8 +5,8 @@ namespace BGC.Scripting
 {
     public class Script
     {
-        List<ScriptDeclaration> scriptDeclarations = new List<ScriptDeclaration>();
-        Dictionary<string, ScriptFunction> scriptFunctions = new Dictionary<string, ScriptFunction>();
+        private readonly List<ScriptDeclaration> scriptDeclarations = new List<ScriptDeclaration>();
+        private readonly Dictionary<string, ScriptFunction> scriptFunctions = new Dictionary<string, ScriptFunction>();
 
         /// <summary>
         /// Parse Script
@@ -44,6 +44,20 @@ namespace BGC.Scripting
             {
                 scriptFunction.ParseFunctions(compilationContext);
             }
+        }
+
+        public bool HasFunction(string identifier) => scriptFunctions.ContainsKey(identifier);
+        public FunctionSignature GetFunctionSignature(string identifier) => scriptFunctions[identifier].functionSignature;
+
+        public bool HasFunction(FunctionSignature functionSignature)
+        {
+            string identifier = functionSignature.identifierToken.identifier;
+            if (!scriptFunctions.ContainsKey(identifier))
+            {
+                return false;
+            }
+
+            return functionSignature.Matches(scriptFunctions[identifier].functionSignature);
         }
 
         public void ParseNextGlobal(
@@ -136,6 +150,8 @@ namespace BGC.Scripting
                         case Keyword.HashSet:
                         case Keyword.Random:
                         case Keyword.DataFile:
+                        case Keyword.IScriptedAlgorithmQuerier:
+                        case Keyword.IMultiParamScriptedAlgorithmQuerier:
                             //Parse Function or Member Declaration
                             {
                                 Type valueType = scriptTokens.ReadType();

--- a/Scripting/Statements/Statement.cs
+++ b/Scripting/Statements/Statement.cs
@@ -267,6 +267,8 @@ namespace BGC.Scripting
                 case Keyword.HashSet:
                 case Keyword.Random:
                 case Keyword.DataFile:
+                case Keyword.IScriptedAlgorithmQuerier:
+                case Keyword.IMultiParamScriptedAlgorithmQuerier:
                     {
                         Type valueType = tokens.ReadType();
 

--- a/Scripting/Tokens/Keyword.cs
+++ b/Scripting/Tokens/Keyword.cs
@@ -44,6 +44,8 @@
         //Other Types
         Random,
         DataFile,
+        IScriptedAlgorithmQuerier,
+        IMultiParamScriptedAlgorithmQuerier,
 
         //Static Types
         System,

--- a/Scripting/Tokens/KeywordToken.cs
+++ b/Scripting/Tokens/KeywordToken.cs
@@ -56,6 +56,9 @@ namespace BGC.Scripting
                 case Keyword.Random: return "Random";
                 case Keyword.DataFile: return "DataFile";
 
+                case Keyword.IScriptedAlgorithmQuerier: return "IScriptedAlgorithmQuerier";
+                case Keyword.IMultiParamScriptedAlgorithmQuerier: return "IMultiParamScriptedAlgorithmQuerier";
+
                 case Keyword.New: return "new";
 
                 default:

--- a/Scripting/Tokens/TokenExtensions.cs
+++ b/Scripting/Tokens/TokenExtensions.cs
@@ -29,6 +29,8 @@ namespace BGC.Scripting
 
                 case Keyword.Random: return typeof(Random);
                 case Keyword.DataFile: return typeof(DataFile);
+                case Keyword.IScriptedAlgorithmQuerier: return typeof(Parameters.Algorithms.Scripted.IScriptedAlgorithmQuerier);
+                case Keyword.IMultiParamScriptedAlgorithmQuerier: return typeof(Parameters.Algorithms.Scripted.IMultiParamScriptedAlgorithmQuerier);
 
                 default:
                     throw new ArgumentException($"Unexpected Keyword: {keyword}");
@@ -60,6 +62,8 @@ namespace BGC.Scripting
 
                 case Keyword.Random:
                 case Keyword.DataFile:
+                case Keyword.IScriptedAlgorithmQuerier:
+                case Keyword.IMultiParamScriptedAlgorithmQuerier:
                     return true;
 
                 default:


### PR DESCRIPTION
Adds a new (default) initialization option for both the ScriptedAlgorithm and the MultiParamScriptedAlgorithm, while maintaining backward compatibility with older versions.

The issue with the original implementation is that scripted algorithms didn't have the capability of querying whether they could perform a given step, and would not receive feedback about trying to step outside the bounds set by the parameters. This would result in failure to step, and the algorithms would not be made aware of it.  Now, algorithms using the new initialization scheme receive an object, either a `IScriptedAlgorithmQuerier` or a `IMultiParamScriptedAlgorithmQuerier`, that allows them to query the outcome of prospective steps.