### PR TITLE
[#PART-159] Serializable State Implemented

### DIFF
--- a/Editor/Tests/Algorithm/AdaptiveScanAlgorithmTests.cs
+++ b/Editor/Tests/Algorithm/AdaptiveScanAlgorithmTests.cs
@@ -18,17 +18,24 @@ namespace BGC.Tests
             public double stepValue;
             public ControlledBasis ControlledBasis => ControlledBasis.FloatingPoint;
 
+            public int __VERSION__ => 1;
+            
             public void Deserialize(JsonObject data)
             {
                 throw new System.NotImplementedException();
             }
 
+            public bool TryUpgradeVersion(JsonObject serializedData)
+            {
+                return true;
+            }
+            
             public IPropertyGroup GetParent()
             {
                 throw new System.NotImplementedException();
             }
 
-            public JsonObject Serialize()
+            public JsonObject Serialize(bool includeState = false)
             {
                 throw new System.NotImplementedException();
             }

--- a/LightJSON/JsonArray.cs
+++ b/LightJSON/JsonArray.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using BGC.Extensions;
 using LightJson.Serialization;
 
 namespace LightJson
@@ -14,6 +15,100 @@ namespace LightJson
 
         /// <summary>The number of values in this collection.</summary>
         public int Count => items.Count;
+
+        /// <summary>
+        /// Gets the underlying type of the JSON array. Supports boolean, integer, number, string, datetime, and JsonObject.
+        /// </summary>
+        /// <remarks>
+        /// If the value in the array is NULL, then type of JsonValue is returned. If array size is 0, type of
+        /// JsonValue is returned.
+        /// </remarks>
+        public Type GetArrayType()
+        {
+            if (this.Count > 0)
+            {
+                JsonValue firstValue = this[0];
+                if (firstValue.IsBoolean) return typeof(bool);
+                if (firstValue.IsInteger) return typeof(int);
+                if (firstValue.IsNull) return typeof(JsonValue);
+                if (firstValue.IsNumber) return typeof(double);
+                if (firstValue.IsString) return typeof(string);
+                if (firstValue.IsDateTime) return typeof(DateTime);
+                if (firstValue.IsJsonObject) return typeof(JsonObject);
+            }
+
+            return typeof(JsonValue);
+        }
+        
+        public T[] ToArray<T>()
+        {
+            T[] array = new T[items.Count];
+
+            for (int i = 0; i < this.Count; i++)
+            {
+                JsonValue jsonValue = this[i];
+                // Convert the JsonValue to the desired type T
+                T item;
+                if (jsonValue.IsNull)
+                {
+                    // Handle null values as default(T)
+                    item = default;
+                }
+                else
+                {
+                    item = jsonValue.ToValue<T>();
+                }
+
+                array[i] = item;
+            }
+
+            return array;
+        }
+        
+        public List<T> ToList<T>()
+        {
+            List<T> list = new List<T>();
+
+            foreach(JsonValue jsonValue in this.items)
+            {
+                // Convert the JsonValue to the desired type T
+                T item;
+                if (jsonValue.IsNull)
+                {
+                    // Handle null values as default(T)
+                    item = default;
+                }
+                else
+                {
+                    item = jsonValue.ToValue<T>();
+                }
+
+                list.Add(item);
+            }
+
+            return list;
+        }
+        
+        /// <summary>Creates a concrete generic enumerable from the JSON value.</summary>
+        public IEnumerable<T> ToEnumerable<T>()
+        {
+            foreach (JsonValue jsonValue in this)
+            {
+                // Convert the JsonValue to the desired type T
+                T item;
+                if (jsonValue.IsNull)
+                {
+                    // Handle null values as default(T)
+                    item = default;
+                }
+                else
+                {
+                    item = jsonValue.ToValue<T>();
+                }
+                yield return item;
+            }
+        }
+
 
         /// <summary>The value at the given index.</summary>
         /// <param name="index">The zero-based index of the value.</param>

--- a/LightJSON/JsonValue.cs
+++ b/LightJSON/JsonValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Collections.Generic;
 using LightJson.Serialization;
@@ -28,6 +29,79 @@ namespace LightJson
         /// <summary>Indicates whether this JsonValue is a Boolean.</summary>
         public bool IsBoolean => Type == JsonValueType.Boolean;
 
+        /// <summary>Converts the JSON value to a concrete C# value with a specific type.</summary>
+        /// <exception cref="NotSupportedException">Thrown if the type requested is not supported.</exception>
+        /// <exception cref="Exception">Thrown if the requested type does not match the underlying JSON type.</exception>
+        public T ToValue<T>()
+        {
+            Type genericType = typeof(T);
+            bool throwTypeException = false;
+            if (genericType == typeof(bool))
+            {
+                if (this.IsBoolean) return (T) Convert.ChangeType(this.AsBoolean, typeof(T));
+                throwTypeException = true;
+            }
+
+            if (genericType == typeof(int))
+            {
+                if(this.IsInteger) return (T) Convert.ChangeType(this.AsInteger, typeof(T));
+                throwTypeException = true;
+            }
+
+            if (genericType == typeof(float) || typeof(T) == typeof(double) || typeof(T) == typeof(decimal))
+            {
+                if(this.IsNumber) return (T) Convert.ChangeType(this.AsNumber, typeof(T));
+                throwTypeException = true;
+            }
+
+            if (genericType == typeof(string))
+            {
+                if(this.IsString) return (T) Convert.ChangeType(this.AsString, typeof(T));
+                throwTypeException = true;
+            }
+
+            if (genericType == typeof(DateTime))
+            {
+                if(this.IsDateTime) return (T) Convert.ChangeType(this.AsDateTime, typeof(T));
+                throwTypeException = true;
+            }
+
+            if (throwTypeException)
+            {
+                throw new Exception(
+                    $"Type of {genericType} was requested, but the underlying JSON Value is not {genericType}. The underlying value is {this.Type}");
+            }
+            
+            throw new NotSupportedException($"Type of {genericType} is not supported.");
+        }
+        
+        /// <summary>Helper method that converts the value to an array, if possible.</summary>
+        /// <exception cref="Exception">Thrown if the underlying type of the JSON value is NOT an array.</exception>
+        public T[] ToArray<T>()
+        {
+            if (this.IsJsonArray) return this.AsJsonArray.ToArray<T>();
+
+            throw new Exception($"Underlying JSON type is not array. It is {this.Type}");
+        }
+
+        /// <summary>Helper method that converts the value to a list, if possible.</summary>
+        /// <exception cref="Exception">Thrown if the underlying type of the JSON value is NOT a list.</exception>
+        public List<T> ToList<T>()
+        {
+            if (this.IsJsonArray) return this.AsJsonArray.ToList<T>();
+            
+            throw new Exception($"Underlying JSON type is not a list. It is {this.Type}");
+        }
+
+        /// <summary>Helper method that converts the value to an enumerable, if possible.</summary>
+        /// <exception cref="Exception">Thrown if the underlying type of the JSON value is NOT a collection.</exception>
+        public IEnumerable<T> ToEnumerable<T>()
+        {
+            if (this.IsJsonArray) return this.AsJsonArray.ToEnumerable<T>();
+            
+            throw new Exception($"Underlying JSON type is not a list. It is {this.Type}");
+        }
+        
         /// <summary>Indicates whether this JsonValue is an Integer.</summary>
         public bool IsInteger
         {
@@ -154,6 +228,7 @@ namespace LightJson
         /// <summary>This value as an JsonArray.</summary>
         public JsonArray AsJsonArray => IsJsonArray ? (JsonArray)reference : null;
 
+       
         /// <summary>This value as a System.DateTime.</summary>
         public DateTime? AsDateTime
         {

--- a/Parameters/CommonPropertyGroup.cs
+++ b/Parameters/CommonPropertyGroup.cs
@@ -20,11 +20,19 @@ namespace BGC.Parameters
 
         private IPropertyGroup _parentPropertyGroup;
 
+        public virtual int __VERSION__ => 1; 
+        
         IPropertyGroup IPropertyGroup.GetParent() => _parentPropertyGroup;
         void IPropertyGroup.SetParent(IPropertyGroup parent) => _parentPropertyGroup = parent;
 
-        public virtual JsonObject Serialize() => this.Internal_GetSerializedData();
+        public virtual JsonObject Serialize(bool includeState = false) => this.Internal_GetSerializedData(includeState);
         public virtual void Deserialize(JsonObject data) => this.Internal_Deserialize(data);
+
+        public virtual bool TryUpgradeVersion(JsonObject serializedData)
+        {
+            // By default, the base class has no upgrades. This would be implemented on a per-child basis, if needed.
+            return true;
+        }
 
         #endregion IPropertyGroup
     }

--- a/Parameters/ControlledParameters/ControlledParameterTemplate.cs
+++ b/Parameters/ControlledParameters/ControlledParameterTemplate.cs
@@ -36,7 +36,7 @@ namespace BGC.Parameters
         protected double GetThresholdValue(double thresholdStepValue) =>
             controlledParameter.GetPartialStepValue(thresholdStepValue, this);
 
-        JsonObject IPropertyGroup.Serialize()
+        JsonObject IPropertyGroup.Serialize(bool includeState = false)
         {
             JsonObject baseData = this.Internal_GetSerializedData();
             baseData.Add("Path", controlledParameter.GetGroupPath(true));

--- a/Parameters/ParameterAttributes/SerializableStateAttribute.cs
+++ b/Parameters/ParameterAttributes/SerializableStateAttribute.cs
@@ -11,18 +11,25 @@ namespace BGC.Parameters
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public class SerializableStateAttribute : Attribute
     {
+        /// <summary>The key name of the property to use for serializing/deserializing in JSON.</summary>
         public string FieldName { get; }
+
+        /// <summary>
+        /// The default value to use if the field is missing from a serialized JSON object when deserializing.
+        /// </summary>
         public JsonValue DefaultValue { get; }
 
         /// <summary>
         /// Specifies this property or field as a serializable state variable that can be serialized by IPropertyGroup.
         /// </summary>
-        /// <param name="fieldName"></param>
-        /// <param name="defaultValue"></param>
-        public SerializableStateAttribute(string fieldName, string defaultValue)
+        /// <param name="fieldName">The key name of the property to use for serializing/deserializing in JSON.</param>
+        /// <param name="defaultDeserializationValue">
+        /// The default value to use if the field is missing from a serialized JSON object when deserializing.
+        /// </param>
+        public SerializableStateAttribute(string fieldName, string defaultDeserializationValue)
         {
             this.FieldName = fieldName;
-            this.DefaultValue = JsonValue.Parse(defaultValue);
+            this.DefaultValue = JsonValue.Parse(defaultDeserializationValue);
         }
     }
 }

--- a/Parameters/ParameterAttributes/SerializableStateAttribute.cs
+++ b/Parameters/ParameterAttributes/SerializableStateAttribute.cs
@@ -11,8 +11,8 @@ namespace BGC.Parameters
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public class SerializableStateAttribute : Attribute
     {
-        public readonly string fieldName;
-        public readonly JsonValue defaultValue;
+        public string FieldName { get; }
+        public JsonValue DefaultValue { get; }
 
         /// <summary>
         /// Specifies this property or field as a serializable state variable that can be serialized by IPropertyGroup.
@@ -21,44 +21,8 @@ namespace BGC.Parameters
         /// <param name="defaultValue"></param>
         public SerializableStateAttribute(string fieldName, string defaultValue)
         {
-            this.fieldName = fieldName;
-            this.defaultValue = JsonValue.Parse(defaultValue);
-            // Type defaultValueType = defaultValue.GetType();
-            // switch (defaultValueType.Name)
-            // {
-            //     case "Single":
-            //         this.defaultValue =  Convert.ToSingle(defaultValue);
-            //         break;
-            //
-            //     case "Double":
-            //         this.defaultValue =  Convert.ToDouble(defaultValue);
-            //         break;
-            //
-            //     case "Int32":
-            //         this.defaultValue =  Convert.ToInt32(defaultValue);
-            //         break;
-            //
-            //     case "Int64":
-            //         this.defaultValue =  Convert.ToInt64(defaultValue);
-            //         break;
-            //
-            //     case "String":
-            //         this.defaultValue =  Convert.ToString(defaultValue);
-            //         break;
-            //
-            //     case "Boolean":
-            //         this.defaultValue =  Convert.ToBoolean(defaultValue);
-            //         break;
-            //
-            //     default:
-            //         if (defaultValueType.IsEnum)
-            //         {
-            //             this.defaultValue = defaultValue.ToString();
-            //             break;
-            //         }
-            //         Debug.LogError($"SerializableStateAttribute: Unsupported datatype ({defaultValueType.Name}) for variable {defaultValue}");
-            //         break;
-            // }
+            this.FieldName = fieldName;
+            this.DefaultValue = JsonValue.Parse(defaultValue);
         }
     }
 }

--- a/Parameters/ParameterAttributes/SerializableStateAttribute.cs
+++ b/Parameters/ParameterAttributes/SerializableStateAttribute.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using LightJson;
+using UnityEngine;
+using UnityEngine.Scripting;
+
+namespace BGC.Parameters
+{
+    /// <summary>
+    /// Specifies that an attribute should be saved to a property group's __STATE__ JSON object during serialization.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class SerializableStateAttribute : Attribute
+    {
+        public readonly string fieldName;
+        public readonly JsonValue defaultValue;
+
+        /// <summary>
+        /// Specifies this property or field as a serializable state variable that can be serialized by IPropertyGroup.
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <param name="defaultValue"></param>
+        public SerializableStateAttribute(string fieldName, string defaultValue)
+        {
+            this.fieldName = fieldName;
+            this.defaultValue = JsonValue.Parse(defaultValue);
+            // Type defaultValueType = defaultValue.GetType();
+            // switch (defaultValueType.Name)
+            // {
+            //     case "Single":
+            //         this.defaultValue =  Convert.ToSingle(defaultValue);
+            //         break;
+            //
+            //     case "Double":
+            //         this.defaultValue =  Convert.ToDouble(defaultValue);
+            //         break;
+            //
+            //     case "Int32":
+            //         this.defaultValue =  Convert.ToInt32(defaultValue);
+            //         break;
+            //
+            //     case "Int64":
+            //         this.defaultValue =  Convert.ToInt64(defaultValue);
+            //         break;
+            //
+            //     case "String":
+            //         this.defaultValue =  Convert.ToString(defaultValue);
+            //         break;
+            //
+            //     case "Boolean":
+            //         this.defaultValue =  Convert.ToBoolean(defaultValue);
+            //         break;
+            //
+            //     default:
+            //         if (defaultValueType.IsEnum)
+            //         {
+            //             this.defaultValue = defaultValue.ToString();
+            //             break;
+            //         }
+            //         Debug.LogError($"SerializableStateAttribute: Unsupported datatype ({defaultValueType.Name}) for variable {defaultValue}");
+            //         break;
+            // }
+        }
+    }
+}

--- a/Parameters/ParameterAttributes/SerializableStateAttribute.cs.meta
+++ b/Parameters/ParameterAttributes/SerializableStateAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d30d66b93ac2411c8a170c1f0cdb92d2
+timeCreated: 1696549054


### PR DESCRIPTION
This is a first pass at a serializable state implementation as per [PART-159](https://bgc.youtrack.cloud/issue/PART-159).

# SerializableStateAttribute
The `SerializableStateAttribute` can be used to decorate readable and writable properties and fields on a class. When something is decorated with the attribute, then the `IPropertyGroup.Internal_GetSerializedData` method will pull the reflection data for the decorated fields if the `includeStateData` flag is set to true. It does this by calling `IPropertyGroup.Internal_GetSerializedStateData`. The reflection data is then parsed into concrete types.

The attribute is also used when `IPropertyGroup.Internal_RawDeserialize` is called. This method will invoke `IPropertyGroup.Internal_DeserializeStateData`, which will return all reflection data for fields decorated with `SerializableState`. The `defaultDeserializationValue` property on the attribute is used during deserialization in the situation where the serialized data does NOT have the field defined by the `SerializableStateAttribute.FieldName` property.

Currently, the `defaultDeserializationValue` is a string due to the limitations of C# Attributes not being generic and not allow `JsonValue` types to be used directly. Therefore, all data is stringified first and put into a JsonValue in the constructor.

## Supported data types
- Double
- Int
- String
- Bool
- Enum
- Array
- List
- IEnumerable

## Example Usage
```csharp
[DisplayInputField(nameof(TestInt))]
[SerializableState(nameof(TestInt), "10")]
public int TestInt { get; set; }

[SerializableState(nameof(IntArray), "[2, 4, 1]")]
public int[] IntArray { get; set; }

[SerializableState(nameof(DoubleList), "[]")]
public List<double> DoubleList { get; set; } = new();

[SerializableState(nameof(BoolEnumerable), "[]")]
public IEnumerable<bool> BoolEnumerable { get; set; }

[SerializableState("TestDoubleField", "2.0")]
private double testDoubleField = 2d;
```

## Example Output
When serializing the state is enabled, then a `__STATE__` object is added to the root level of the property group. The following is an example from a unit test.
```json
{
	"Type": "Test Property Group",
	"__VERSION__": 3,
	"TestInt": 10,
	"Time Constraint": {
		"Type": "Maximum Time",
		"__VERSION__": 1,
		"MaximumTime": 10,
		"__STATE__": {
			"MaximumTime": 10,
			"ElapsedTime": 1697146297955.91,
			"StartTime": 0
		}
	},
	"__STATE__": {
		"TestInt": 10,
		"IntArray": [
			1,
			2,
			3
		],
		"DoubleList": [
			3,
			2,
			1
		],
		"BoolEnumerable": [
			true,
			false
		],
		"TestDoubleField": 2
	}
}
```

# IPropertyGroup Versioning
`IPropertyGroup` now has versioning supported at the class level. The `__VERSION__` property can be used for upgrading the version of a previously serialized instance to a new version. This is intended to be done using the `IPropertyGroup.TryUpgradeVersion` method. Additionally, the `IPropertyGroup.Serialize` method now has an optional bool `includeState` that, when true, will serialize the state of the property group based on the `SerializableStateAttribute`.

## TryUpgradeVersion
This method is called on during `PropertyGroupExtensions.Internal_RawDeserialize`. The intent is to make sure a serialized object coming in is upgraded to the current version to ensure proper deserialization. This allows us granular versioning control over individual property groups, if needed.

# Json Helpers
As part of serializing and deserializing concrete types via reflection, some helper methods were added to `JsonArray` and `JsonValue`.

## JsonArray Helpers
- **GetArrayType()**: Specifies the type of data the array contains
- **ToArray<T>()**: Converts a `JsonArray` object to a concrete array of type T.
- **ToList<T>()**: Converts a `JsonArray` object to a concrete list of type T.
- **ToEnumerable<T>()**: Converts a `JsonArray` object to a concrete enumerable of type T.

## JsonValue Helpers
- **ToValue<T>()**: Converts a `JsonValue` to a concrete value of type T.
- **ToArray<T>()**: Converts a `JsonValue` to a concrete array of type T only if the `JsonValue` is a valid JSON array.
- **ToList<T>()**: Converts a `JsonValue` to a concrete List of type T only if the `JsonValue` is a valid JSON array.
- **ToEnumerable<T>()**: Converts a `JsonValue` to a concrete Enumerable of type T only if the `JsonValue` is a valid JSON array.

# Enumerable Serialization
Included in this update is the ability to serialize and deserialize enumerable types (Array, List, and IEnumerable) using reflection. This behavior has been wrapped up in `PropertyGroupExtensions.SerializeEnumerable` and `PropertyGroupExtensions.DeserializeEnumerable`. **This does not support other enumerables like Dictionaries, HashSets, or Collections**.