### PR TITLE
Set CoroutineUtility mono as DontDestroyOnLoad

### DIFF
--- a/Utility/CoroutineUtility.cs
+++ b/Utility/CoroutineUtility.cs
@@ -17,6 +17,7 @@ namespace BGC.Utility
                 {
                     mono = new GameObject().AddComponent<EmptyMonobehaviour>();
                     mono.gameObject.AddComponent<DestroyOnDestroy>();
+                    UnityEngine.Object.DontDestroyOnLoad(mono.gameObject);
                 }
 
                 return mono;


### PR DESCRIPTION
Fixes an issue where coroutines would stop running because the gameobject holding them can get destroyed when changing scenes scenes.