### PR TITLE
Protocol v3: Sequence based sessions and lockouts

### DIFF
--- a/Study/ConcreteLockoutElements.cs
+++ b/Study/ConcreteLockoutElements.cs
@@ -1,0 +1,214 @@
+using LightJson;
+using System;
+using System.Collections.Generic;
+
+namespace BGC.Study
+{
+    public class FixedTimeLockout : LockoutElement
+    {
+        public override string ElementType => "FixedTime";
+
+        public double TimeMinutes { get; private set; }
+        public string BypassPassword { get; private set; }
+
+        public FixedTimeLockout(JsonObject data) : base(data)
+        {
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.Time))
+            {
+                TimeMinutes = data[ProtocolKeys.LockoutElement.Time].AsNumber;
+            }
+
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.BypassPassword))
+            {
+                BypassPassword = data[ProtocolKeys.LockoutElement.BypassPassword].AsString;
+            }
+        }
+
+        public override string GetBypassPassword() => BypassPassword;
+
+        protected override void _PopulateJSONObject(JsonObject jsonObject)
+        {
+            jsonObject.Add(ProtocolKeys.LockoutElement.Time, TimeMinutes);
+            if (!string.IsNullOrEmpty(BypassPassword))
+            {
+                jsonObject.Add(ProtocolKeys.LockoutElement.BypassPassword, BypassPassword);
+            }
+        }
+
+        public override bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes)
+        {
+            if (sequenceTimes == null)
+            {
+                return false;
+            }
+
+            // Filter for sessions
+            List<SequenceTime> sessions = new List<SequenceTime>();
+            foreach (var st in sequenceTimes)
+            {
+                if (st.type == SequenceType.Session)
+                {
+                    sessions.Add(st);
+                }
+            }
+
+            if (sessions.Count == 0)
+            {
+                return false;
+            }
+
+            if (TimeMinutes <= 0)
+            {
+                return false;
+            }
+
+            DateTime lastSessionTime = sessions[sessions.Count - 1].completedTime;
+            TimeSpan timeSinceLastSession = currentTime - lastSessionTime;
+            return timeSinceLastSession.TotalMinutes < TimeMinutes;
+        }
+    }
+
+    public class PasswordLockout : LockoutElement
+    {
+        public override string ElementType => "Password";
+
+        public string Password { get; private set; }
+
+        public PasswordLockout(JsonObject data) : base(data)
+        {
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.Password))
+            {
+                Password = data[ProtocolKeys.LockoutElement.Password].AsString;
+            }
+        }
+
+        protected override void _PopulateJSONObject(JsonObject jsonObject)
+        {
+            if (!string.IsNullOrEmpty(Password))
+            {
+                jsonObject.Add(ProtocolKeys.LockoutElement.Password, Password);
+            }
+        }
+
+        public override bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes)
+        {
+            // Always locked if password exists. The UI handles unlocking via password entry.
+            return !string.IsNullOrEmpty(Password);
+        }
+    }
+
+    public class WindowLockout : LockoutElement
+    {
+        public override string ElementType => "Window";
+
+        public double WindowTimeMinutes { get; private set; }
+        public double MinTimeMinutes { get; private set; }
+        public int MaxSessions { get; private set; }
+        public string BypassPassword { get; private set; }
+
+        public WindowLockout(JsonObject data) : base(data)
+        {
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.WindowTime))
+            {
+                WindowTimeMinutes = data[ProtocolKeys.LockoutElement.WindowTime].AsNumber;
+            }
+
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.MinTime))
+            {
+                MinTimeMinutes = data[ProtocolKeys.LockoutElement.MinTime].AsNumber;
+            }
+
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.MaxSessions))
+            {
+                MaxSessions = data[ProtocolKeys.LockoutElement.MaxSessions].AsInteger;
+            }
+
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.BypassPassword))
+            {
+                BypassPassword = data[ProtocolKeys.LockoutElement.BypassPassword].AsString;
+            }
+        }
+
+        public override string GetBypassPassword() => BypassPassword;
+
+        protected override void _PopulateJSONObject(JsonObject jsonObject)
+        {
+            jsonObject.Add(ProtocolKeys.LockoutElement.WindowTime, WindowTimeMinutes);
+            jsonObject.Add(ProtocolKeys.LockoutElement.MinTime, MinTimeMinutes);
+            jsonObject.Add(ProtocolKeys.LockoutElement.MaxSessions, MaxSessions);
+            if (!string.IsNullOrEmpty(BypassPassword))
+            {
+                jsonObject.Add(ProtocolKeys.LockoutElement.BypassPassword, BypassPassword);
+            }
+        }
+
+        public override bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes)
+        {
+            if (sequenceTimes == null)
+            {
+                return false;
+            }
+
+            // Filter for sessions
+            List<SequenceTime> sessions = new List<SequenceTime>();
+            foreach (var st in sequenceTimes)
+            {
+                if (st.type == SequenceType.Session)
+                {
+                    sessions.Add(st);
+                }
+            }
+
+            if (sessions.Count == 0)
+            {
+                return false;
+            }
+
+            // 1. Check MinTime
+            DateTime lastSessionTime = sessions[sessions.Count - 1].completedTime;
+            TimeSpan timeSinceLastSession = currentTime - lastSessionTime;
+            if (timeSinceLastSession.TotalMinutes < MinTimeMinutes)
+            {
+                return true;
+            }
+
+            // 2. Check Window
+            if (WindowTimeMinutes > 0 && MaxSessions > 0)
+            {
+                // Simulate windows from the beginning of history to determine the current window state
+                DateTime currentWindowStart = sessions[0].completedTime;
+                int sessionsInCurrentWindow = 1;
+
+                for (int i = 1; i < sessions.Count; i++)
+                {
+                    DateTime sessionTime = sessions[i].completedTime;
+
+                    // Is this session inside the current window?
+                    if ((sessionTime - currentWindowStart).TotalMinutes < WindowTimeMinutes)
+                    {
+                        sessionsInCurrentWindow++;
+                    }
+                    else
+                    {
+                        // Start a new window
+                        currentWindowStart = sessionTime;
+                        sessionsInCurrentWindow = 1;
+                    }
+                }
+
+                // Now check against current time
+                // If we are still inside the last established window...
+                if ((currentTime - currentWindowStart).TotalMinutes < WindowTimeMinutes)
+                {
+                    // ...and we have hit the max sessions...
+                    if (sessionsInCurrentWindow >= MaxSessions)
+                    {
+                        return true; // Locked
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Study/ConcreteLockoutElements.cs
+++ b/Study/ConcreteLockoutElements.cs
@@ -84,6 +84,16 @@ namespace BGC.Study
             ProtocolManager.RemoveExtensionState(StateKey);
         }
 
+        public override void ClearLockout()
+        {
+            // Set expiration to the past so the lockout is no longer blocking
+            ProtocolManager.SetExtensionState(StateKey, new JsonValue(new JsonObject
+            {
+                { "expiration", DateTime.MinValue }
+            }));
+            UnityEngine.Debug.Log($"[FixedTimeLockout:{id}] Lockout cleared/skipped");
+        }
+
         public override bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes)
         {
             if (TimeMinutes <= 0)
@@ -270,6 +280,14 @@ namespace BGC.Study
             {
                 jsonObject.Add(ProtocolKeys.LockoutElement.BypassPassword, BypassPassword);
             }
+        }
+
+        public override void ClearLockout()
+        {
+            // Clear all stored state so the lockout is no longer blocking
+            // Removing state effectively expires the window on next check
+            ProtocolManager.RemoveExtensionState(StateKey);
+            UnityEngine.Debug.Log($"[WindowLockout:{id}] Lockout cleared/skipped");
         }
 
         public override void OnLockoutCompleted(DateTime encounteredTime, DateTime completedTime)

--- a/Study/ConcreteLockoutElements.cs.meta
+++ b/Study/ConcreteLockoutElements.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14286b9067eff2047a78946d39697bf4

--- a/Study/IProtocolSequenceMember.cs
+++ b/Study/IProtocolSequenceMember.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace BGC.Study
+{
+    public interface IProtocolSequenceMember
+    {
+        int ID { get; }
+        SequenceType Type { get; }
+
+        /// <summary>
+        /// Checks the status of this sequence member.
+        /// Returns ProtocolStatus.Locked if blocked, 
+        /// ProtocolStatus.SessionReady if ready to play (for sessions),
+        /// or ProtocolStatus.StepCompleted if this step should be skipped/advanced (e.g. passed lockout).
+        /// </summary>
+        ProtocolStatus CheckStatus();
+
+        /// <summary>
+        /// Called when the sequence index first lands on this member.
+        /// Useful for initializing timers or logging encounter times.
+        /// </summary>
+        void OnEncountered();
+
+        /// <summary>
+        /// Called when the sequence advances past this member.
+        /// </summary>
+        void OnCompleted();
+    }
+}

--- a/Study/IProtocolSequenceMember.cs.meta
+++ b/Study/IProtocolSequenceMember.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a87fa9da1fb9de42b60e68fd6fab3f7

--- a/Study/LockoutElement.cs
+++ b/Study/LockoutElement.cs
@@ -65,6 +65,9 @@ namespace BGC.Study
 
         public abstract bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes);
         public virtual string GetBypassPassword() { return null; }
+        public virtual void OnLockoutCompleted(DateTime encounteredTime, DateTime completedTime)
+        {
+        }
 
         public static void HardClear()
         {

--- a/Study/LockoutElement.cs
+++ b/Study/LockoutElement.cs
@@ -124,6 +124,16 @@ namespace BGC.Study
         {
         }
 
+        /// <summary>
+        /// Clears/skips this lockout's stored state so it no longer blocks.
+        /// Used by admin features to bypass time-based lockouts.
+        /// </summary>
+        public virtual void ClearLockout()
+        {
+            // Default implementation does nothing.
+            // Override in concrete classes that have persistent state.
+        }
+
         public static void HardClear()
         {
             nextElementID = 1;

--- a/Study/LockoutElement.cs
+++ b/Study/LockoutElement.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LightJson;
+
+namespace BGC.Study
+{
+    public abstract class LockoutElement
+    {
+        private static int nextElementID = 1;
+
+        public abstract string ElementType { get; }
+        public readonly int id;
+
+        public JsonObject envVals;
+
+        //Deserialized lockoutElements are not added to the LockoutElement dictionary
+        public LockoutElement(JsonObject data)
+        {
+            id = data[ProtocolKeys.LockoutElement.Id];
+            if (nextElementID <= id)
+            {
+                nextElementID = id + 1;
+            }
+
+            if (data.ContainsKey(ProtocolKeys.LockoutElement.EnvironmentValues))
+            {
+                envVals = data[ProtocolKeys.LockoutElement.EnvironmentValues].AsJsonObject;
+            }
+            else
+            {
+                envVals = new JsonObject();
+            }
+        }
+
+        //Explicitly created lockoutElements are added to the dictionary
+        public LockoutElement()
+        {
+            id = nextElementID++;
+
+            envVals = new JsonObject();
+
+            ProtocolManager.lockoutElementDictionary.Add(id, this);
+        }
+
+        public JsonObject SerializeElement()
+        {
+            JsonObject lockoutElement = new JsonObject()
+            {
+                { ProtocolKeys.LockoutElement.Id, id },
+                { ProtocolKeys.LockoutElement.Type, ElementType }
+            };
+
+            if (envVals.Count > 0)
+            {
+                lockoutElement.Add(ProtocolKeys.LockoutElement.EnvironmentValues, envVals);
+            }
+
+            _PopulateJSONObject(lockoutElement);
+
+            return lockoutElement;
+        }
+
+        protected abstract void _PopulateJSONObject(JsonObject jsonObject);
+
+        public abstract bool CheckLockout(DateTime currentTime, IEnumerable<SequenceTime> sequenceTimes);
+        public virtual string GetBypassPassword() { return null; }
+
+        public static void HardClear()
+        {
+            nextElementID = 1;
+        }
+    }
+}

--- a/Study/LockoutElement.cs.meta
+++ b/Study/LockoutElement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e00a93199ea7f784ab803ab85cdc4231

--- a/Study/Protocol.cs
+++ b/Study/Protocol.cs
@@ -1,25 +1,44 @@
-﻿using System;
+﻿using LightJson;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
-using LightJson;
 
 namespace BGC.Study
 {
-    public class Protocol : IEnumerable<SessionID>
+    public class Protocol : IEnumerable<SequenceElement>
     {
         private static int nextProtocolID = 1;
         public readonly string key;
 
         public string name;
-        public List<SessionID> sessions;
+        public List<SequenceElement> sequences;
         public JsonObject envVals;
+
+        public List<Session> Sessions => sequences
+            .Where(seq => seq.type == SequenceType.Session)
+            .Select(seq => seq.Session)
+            .Where(session => session != null)
+            .ToList();
+
+        public List<Lockout> Lockouts => sequences
+            .Where(seq => seq.type == SequenceType.Lockout)
+            .Select(seq => seq.Lockout)
+            .Where(lockout => lockout != null)
+            .ToList();
+
+        public int SessionCount => sequences.Count(seq => seq.type == SequenceType.Session);
+        public int LockoutCount => sequences.Count(seq => seq.type == SequenceType.Lockout);
 
         private static class Keys
         {
             //Attributes
             public const string Name = "Name";
             public const string SessionIDs = "Sessions";
+            public const string Sequence = "Sequence";
 
             //Dictionary
             public const string EnvironmentValues = "Env";
@@ -30,7 +49,7 @@ namespace BGC.Study
         public Protocol()
         {
             key = (nextProtocolID++).ToString();
-            sessions = new List<SessionID>();
+            sequences = new List<SequenceElement>();
             envVals = new JsonObject();
 
             ProtocolManager.protocolDictionary.Add(key, this);
@@ -49,7 +68,7 @@ namespace BGC.Study
         {
             this.name = name;
             this.key = key;
-            sessions = new List<SessionID>();
+            sequences = new List<SequenceElement>();
             envVals = new JsonObject();
 
             ProtocolManager.protocolDictionary.Add(key, this);
@@ -75,10 +94,22 @@ namespace BGC.Study
             name = data[Keys.Name];
             this.key = key;
 
-            sessions = new List<SessionID>();
-            foreach (int sessionID in data[Keys.SessionIDs].AsJsonArray)
+            sequences = new List<SequenceElement>();
+            if (data.ContainsKey(Keys.SessionIDs))
             {
-                sessions.Add(sessionID);
+                foreach (int sessionID in data[Keys.SessionIDs].AsJsonArray)
+                {
+                    sequences.Add(new SequenceElement(sessionID, SequenceType.Session));
+                }
+            }
+            else if (data.ContainsKey(Keys.Sequence))
+            {
+                foreach (JsonObject sequenceElement in data[Keys.Sequence].AsJsonArray)
+                {
+                    int id = sequenceElement["Id"];
+                    string type = sequenceElement["Type"];
+                    sequences.Add(new SequenceElement(id, type));
+                }
             }
 
             if (data.ContainsKey(Keys.EnvironmentValues))
@@ -93,37 +124,66 @@ namespace BGC.Study
 
         public JsonObject ToJson()
         {
-            JsonArray jsonSessionIDs = new JsonArray();
-            foreach (SessionID sessionID in sessions)
+            // Prefer serializing as sessions unless lockouts are present
+            if (sequences.TrueForAll(seq => seq.type == SequenceType.Session))
             {
-                jsonSessionIDs.Add(sessionID.id);
+                JsonArray sessionIDs = new();
+                foreach (SequenceElement sequence in sequences)
+                {
+                    sessionIDs.Add(sequence.id);
+                }
+
+                JsonObject serializedData = new()
+                {
+                    { Keys.Name, name },
+                    { Keys.SessionIDs, sessionIDs }
+                };
+
+                if (envVals.Count > 0)
+                {
+                    serializedData.Add(Keys.EnvironmentValues, envVals);
+                }
+
+                return serializedData;
             }
-
-            JsonObject serializedData = new JsonObject()
+            else
             {
-                { Keys.Name, name },
-                { Keys.SessionIDs, jsonSessionIDs }
-            };
+                JsonArray jsonSequences = new JsonArray();
+                foreach (SequenceElement sequence in sequences)
+                {
+                    JsonObject sequenceObject = new()
+                    {
+                        { ProtocolKeys.SequenceElement.Type, SequenceElement.SequenceTypeNames[sequence.type] },
+                        { ProtocolKeys.SequenceElement.Id, sequence.id }
+                    };
+                    jsonSequences.Add(sequenceObject);
+                }
 
-            if (envVals.Count > 0)
-            {
-                serializedData.Add(Keys.EnvironmentValues, envVals);
+                JsonObject serializedData = new()
+                {
+                    { Keys.Name, name },
+                    { Keys.Sequence, jsonSequences }
+                };
+
+                if (envVals.Count > 0)
+                {
+                    serializedData.Add(Keys.EnvironmentValues, envVals);
+                }
+                return serializedData;
             }
-
-            return serializedData;
         }
 
-        public int Count => sessions.Count;
+        public int Count => sequences.Count;
 
-        public Session this[int i] => sessions[i].Session;
+        public SequenceElement this[int i] => sequences[i];
 
-        public void Add(Session session) => sessions.Add(session);
+        public void Add(SequenceElement sequence) => sequences.Add(sequence);
 
-        public void AddRange(IEnumerable<Session> sessions)
+        public void AddRange(IEnumerable<SequenceElement> sequenceElements)
         {
-            foreach (Session session in sessions)
+            foreach (SequenceElement sequence in sequenceElements)
             {
-                this.sessions.Add(session);
+                sequences.Add(sequence);
             }
         }
 
@@ -134,13 +194,13 @@ namespace BGC.Study
 
         #region IEnumerator
 
-        IEnumerator<SessionID> IEnumerable<SessionID>.GetEnumerator() => sessions.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => sessions.GetEnumerator();
+        IEnumerator<SequenceElement> IEnumerable<SequenceElement>.GetEnumerator() => sequences.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => sequences.GetEnumerator();
 
         #endregion IEnumerator
     }
 
-    public class Session : IEnumerable<SessionElementID>
+    public class Session : IEnumerable<SessionElementID>, IProtocolSequenceMember
     {
         private static int nextSessionID = 1;
         public readonly int id;
@@ -201,6 +261,9 @@ namespace BGC.Study
 
         public int Count => sessionElements.Count;
         public SessionElement this[int i] => sessionElements[i].Element;
+
+        public int ID => id;
+        public SequenceType Type => SequenceType.Session;
 
         public void Add(SessionElement element)
         {
@@ -304,10 +367,181 @@ namespace BGC.Study
             nextSessionID = 1;
         }
 
+        public ProtocolStatus CheckStatus()
+        {
+            string password = GetPassword();
+            if (!string.IsNullOrEmpty(password))
+            {
+                return ProtocolStatus.Locked;
+            }
+
+            return ProtocolStatus.SessionReady;
+        }
+
+        public void OnEncountered()
+        {
+            ProtocolManager.CurrentSequenceStartTime = DateTime.Now;
+        }
+
+        public void OnCompleted()
+        {
+            ProtocolManager.AddSequenceTime(
+                new SequenceTime(SequenceType.Session, id, ProtocolManager.CurrentSequenceStartTime, DateTime.Now));
+        }
+
         #region IEnumerator
 
         IEnumerator<SessionElementID> IEnumerable<SessionElementID>.GetEnumerator() => sessionElements.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => sessionElements.GetEnumerator();
+
+        #endregion IEnumerator
+    }
+
+    public class Lockout : IEnumerable<LockoutElementID>, IProtocolSequenceMember
+    {
+        private static int nextLockoutID = 1;
+        public readonly int id;
+
+        public List<LockoutElementID> lockoutElements;
+        public JsonObject envVals;
+
+        public static class Keys
+        {
+            // Attributes
+            public const string Id = "Id";
+            public const string LockoutElementIDs = "Elements";
+
+            // Dictionary
+            public const string EnvironmentValues = "Env";
+        }
+
+        // Explicitly created lockouts are added to the Lockout dictionary
+        public Lockout()
+        {
+            id = nextLockoutID++;
+            lockoutElements = new List<LockoutElementID>();
+            envVals = new JsonObject();
+
+            ProtocolManager.lockoutDictionary.Add(id, this);
+        }
+
+        /// <summary>
+        /// Deserialization Constructor
+        /// Deserialized Lockouts are not added to the Lockout dictionary
+        /// </summary>
+        public Lockout(JsonObject lockoutData)
+        {
+            id = lockoutData[Keys.Id];
+
+            if (nextLockoutID <= id)
+            {
+                nextLockoutID = id + 1;
+            }
+
+            lockoutElements = new List<LockoutElementID>();
+            foreach (int lockoutElementID in lockoutData[Keys.LockoutElementIDs].AsJsonArray)
+            {
+                lockoutElements.Add(lockoutElementID);
+            }
+
+            if (lockoutData.ContainsKey(Keys.EnvironmentValues))
+            {
+                envVals = lockoutData[Keys.EnvironmentValues].AsJsonObject;
+            }
+            else
+            {
+                envVals = new JsonObject();
+            }
+        }
+
+        public int Count => lockoutElements.Count;
+        public LockoutElement this[int i] => lockoutElements[i].Element;
+
+        public int ID => id;
+        public SequenceType Type => SequenceType.Lockout;
+
+        public void Add(LockoutElement element)
+        {
+            if (element != null)
+            {
+                lockoutElements.Add(element);
+            }
+        }
+
+        public void AddRange(IEnumerable<LockoutElement> elements)
+        {
+            foreach (LockoutElement element in elements)
+            {
+                if (element != null)
+                {
+                    lockoutElements.Add(element);
+                }
+            }
+        }
+
+        public JsonObject SerializeLockout()
+        {
+            JsonArray jsonElementsIDs = new JsonArray();
+            foreach (LockoutElementID elementID in lockoutElements)
+            {
+                jsonElementsIDs.Add(elementID.id);
+            }
+
+            JsonObject newLockout = new JsonObject()
+            {
+                { Keys.Id, id },
+                { Keys.LockoutElementIDs, jsonElementsIDs }
+            };
+
+            if (envVals.Count > 0)
+            {
+                newLockout.Add(Keys.EnvironmentValues, envVals);
+            }
+
+            return newLockout;
+        }
+
+        public static void HardClear()
+        {
+            nextLockoutID = 1;
+        }
+
+        public ProtocolStatus CheckStatus()
+        {
+            foreach (LockoutElementID elementId in lockoutElements)
+            {
+                LockoutElement element = elementId.Element;
+                if (element == null)
+                {
+                    Debug.LogError($"Lockout element is null for ID: {elementId.id}");
+                    continue;
+                }
+
+                if (element.CheckLockout(DateTime.Now, ProtocolManager.SequenceTimes))
+                {
+                    ProtocolManager.currentLockout = this;
+                    return ProtocolStatus.Locked;
+                }
+            }
+
+            return ProtocolStatus.StepCompleted;
+        }
+
+        public void OnEncountered()
+        {
+            ProtocolManager.CurrentSequenceStartTime = DateTime.Now;
+        }
+
+        public void OnCompleted()
+        {
+            ProtocolManager.AddSequenceTime(
+                new SequenceTime(SequenceType.Lockout, id, ProtocolManager.CurrentSequenceStartTime, DateTime.Now));
+        }
+
+        #region IEnumerator
+
+        IEnumerator<LockoutElementID> IEnumerable<LockoutElementID>.GetEnumerator() => lockoutElements.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => lockoutElements.GetEnumerator();
 
         #endregion IEnumerator
     }
@@ -335,19 +569,64 @@ namespace BGC.Study
         public static implicit operator ProtocolID(string id) => new ProtocolID(id);
     }
 
-    public readonly struct SessionID
+    public enum SequenceType
     {
+        Session,
+        Lockout
+    }
+
+    public readonly struct SequenceElement
+    {
+        public static readonly ReadOnlyDictionary<SequenceType, string> SequenceTypeNames =
+            new(new Dictionary<SequenceType, string>()
+            {
+                { SequenceType.Session, "Session" },
+                { SequenceType.Lockout, "Lockout" }
+            });
+
+        public static readonly ReadOnlyDictionary<string, SequenceType> SequenceTypeFromNames =
+            new(new Dictionary<string, SequenceType>()
+            {
+                { "Session", SequenceType.Session },
+                { "Lockout", SequenceType.Lockout }
+            });
+
         public readonly int id;
-        public Session Session => ProtocolManager.sessionDictionary.ContainsKey(id) ?
+        public readonly SequenceType type;
+
+        public Session Session => type == SequenceType.Session && 
+            ProtocolManager.sessionDictionary.ContainsKey(id) ?
             ProtocolManager.sessionDictionary[id] : null;
 
-        public SessionID(int id)
+        public Lockout Lockout => type == SequenceType.Lockout && 
+            ProtocolManager.lockoutDictionary.ContainsKey(id) ?
+            ProtocolManager.lockoutDictionary[id] : null;
+
+        public SequenceElement(int id, SequenceType type)
         {
             this.id = id;
+            this.type = type;
         }
 
-        public static implicit operator SessionID(Session session) => new SessionID(session.id);
-        public static implicit operator SessionID(int id) => new SessionID(id);
+        public SequenceElement(int id, string type)
+        {
+            this.id = id;
+
+            if (SequenceTypeFromNames.ContainsKey(type))
+            {
+                this.type = SequenceTypeFromNames[type];
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid sequence type name: {type}");
+            }
+        }
+
+        public static implicit operator SequenceElement(Session session) =>
+            new SequenceElement(session.id, SequenceType.Session);
+
+        public static implicit operator SequenceElement(Lockout lockout) =>
+            new SequenceElement(lockout.id, SequenceType.Lockout);
     }
 
     public readonly struct SessionElementID
@@ -363,5 +642,18 @@ namespace BGC.Study
 
         public static implicit operator SessionElementID(SessionElement element) => new SessionElementID(element.id);
         public static implicit operator SessionElementID(int id) => new SessionElementID(id);
+    }
+
+    public readonly struct LockoutElementID
+    {
+        public readonly int id;
+        public LockoutElement Element => ProtocolManager.lockoutElementDictionary.ContainsKey(id) ?
+            ProtocolManager.lockoutElementDictionary[id] : null;
+        public LockoutElementID(int id)
+        {
+            this.id = id;
+        }
+        public static implicit operator LockoutElementID(LockoutElement element) => new LockoutElementID(element.id);
+        public static implicit operator LockoutElementID(int id) => new LockoutElementID(id);
     }
 }

--- a/Study/Protocol.cs
+++ b/Study/Protocol.cs
@@ -124,53 +124,28 @@ namespace BGC.Study
 
         public JsonObject ToJson()
         {
-            // Prefer serializing as sessions unless lockouts are present
-            if (sequences.TrueForAll(seq => seq.type == SequenceType.Session))
+            JsonArray jsonSequences = new JsonArray();
+            foreach (SequenceElement sequence in sequences)
             {
-                JsonArray sessionIDs = new();
-                foreach (SequenceElement sequence in sequences)
+                JsonObject sequenceObject = new()
                 {
-                    sessionIDs.Add(sequence.id);
-                }
-
-                JsonObject serializedData = new()
-                {
-                    { Keys.Name, name },
-                    { Keys.SessionIDs, sessionIDs }
+                    { ProtocolKeys.SequenceElement.Type, SequenceElement.SequenceTypeNames[sequence.type] },
+                    { ProtocolKeys.SequenceElement.Id, sequence.id }
                 };
-
-                if (envVals.Count > 0)
-                {
-                    serializedData.Add(Keys.EnvironmentValues, envVals);
-                }
-
-                return serializedData;
+                jsonSequences.Add(sequenceObject);
             }
-            else
+
+            JsonObject serializedData = new()
             {
-                JsonArray jsonSequences = new JsonArray();
-                foreach (SequenceElement sequence in sequences)
-                {
-                    JsonObject sequenceObject = new()
-                    {
-                        { ProtocolKeys.SequenceElement.Type, SequenceElement.SequenceTypeNames[sequence.type] },
-                        { ProtocolKeys.SequenceElement.Id, sequence.id }
-                    };
-                    jsonSequences.Add(sequenceObject);
-                }
+                { Keys.Name, name },
+                { Keys.Sequence, jsonSequences }
+            };
 
-                JsonObject serializedData = new()
-                {
-                    { Keys.Name, name },
-                    { Keys.Sequence, jsonSequences }
-                };
-
-                if (envVals.Count > 0)
-                {
-                    serializedData.Add(Keys.EnvironmentValues, envVals);
-                }
-                return serializedData;
+            if (envVals.Count > 0)
+            {
+                serializedData.Add(Keys.EnvironmentValues, envVals);
             }
+            return serializedData;
         }
 
         public int Count => sequences.Count;

--- a/Study/Protocol.cs
+++ b/Study/Protocol.cs
@@ -534,8 +534,17 @@ namespace BGC.Study
 
         public void OnCompleted()
         {
+            DateTime encounteredTime = ProtocolManager.CurrentSequenceStartTime;
+            DateTime completedTime = DateTime.Now;
+
             ProtocolManager.AddSequenceTime(
-                new SequenceTime(SequenceType.Lockout, id, ProtocolManager.CurrentSequenceStartTime, DateTime.Now));
+                new SequenceTime(SequenceType.Lockout, id, encounteredTime, completedTime));
+
+            foreach (LockoutElementID elementId in lockoutElements)
+            {
+                LockoutElement element = elementId.Element;
+                element?.OnLockoutCompleted(encounteredTime, completedTime);
+            }
         }
 
         #region IEnumerator

--- a/Study/Protocol.cs
+++ b/Study/Protocol.cs
@@ -310,6 +310,7 @@ namespace BGC.Study
             return newSession;
         }
 
+        [Obsolete("Use PasswordLockout sequence elements instead. This method is only for migration compatibility.")]
         public Session SetPassword(string password)
         {
             if (!string.IsNullOrWhiteSpace(password))
@@ -323,6 +324,7 @@ namespace BGC.Study
             return this;
         }
 
+        [Obsolete("Use PasswordLockout sequence elements instead. This method is only for migration compatibility.")]
         public string GetPassword()
         {
             if (envVals.ContainsKey(Keys.PasswordId) && envVals[Keys.PasswordId].IsString)
@@ -336,6 +338,7 @@ namespace BGC.Study
             return null;
         }
 
+        [Obsolete("Use FixedTimeLockout sequence elements instead. This method is only for migration compatibility.")]
         public Session SetLockoutMinutes(int lockoutMinutes)
         {
             if (lockoutMinutes > 0)
@@ -349,6 +352,7 @@ namespace BGC.Study
             return this;
         }
 
+        [Obsolete("Use FixedTimeLockout sequence elements instead. This method is only for migration compatibility.")]
         public int GetLockoutMinutes()
         {
             if (envVals.ContainsKey(Keys.LockoutMinutes))
@@ -369,12 +373,8 @@ namespace BGC.Study
 
         public ProtocolStatus CheckStatus()
         {
-            string password = GetPassword();
-            if (!string.IsNullOrEmpty(password))
-            {
-                return ProtocolStatus.Locked;
-            }
-
+            // All lockouts are now handled via the sequence system.
+            // Session-level passwords are migrated to PasswordLockout elements during protocol load.
             return ProtocolStatus.SessionReady;
         }
 

--- a/Study/ProtocolKeys.cs
+++ b/Study/ProtocolKeys.cs
@@ -10,7 +10,9 @@ namespace BGC.Study
         //Arrays
         public const string Protocols = "Protocols";
         public const string Sessions = "Sessions";
+        public const string Lockouts = "Lockouts";
         public const string SessionElements = "SessionElements";
+        public const string LockoutElements = "LockoutElements";
 
         //
         //Elements
@@ -24,6 +26,29 @@ namespace BGC.Study
 
             //Dictionary
             public const string ElementType = "Type";
+        }
+
+        public static class LockoutElement
+        {
+            //Attributes
+            public const string Id = "Id";
+            public const string EnvironmentValues = "Env";
+            
+            //Dictionary
+            public const string Type = "Type";
+            public const string Time = "Time";
+            public const string BypassPassword = "BypassPassword";
+            public const string Password = "Password";
+            public const string WindowTime = "WindowTime";
+            public const string MinTime = "MinTime";
+            public const string MaxSessions = "MaxSessions";
+        }
+
+        public static class SequenceElement
+        {
+            // Attributes
+            public const string Id = "Id";
+            public const string Type = "Type";
         }
     }
 }

--- a/Study/ProtocolKeys.cs
+++ b/Study/ProtocolKeys.cs
@@ -49,6 +49,21 @@ namespace BGC.Study
             // Attributes
             public const string Id = "Id";
             public const string Type = "Type";
+
+            // Type values
+            public const string SessionType = "Session";
+            public const string LockoutType = "Lockout";
+
+            /// <summary>
+            /// Determines if a sequence element type can be the final element in a protocol sequence.
+            /// This mirrors the CanBeFinalElement property on IProtocolSequenceMember but works with
+            /// type strings before instantiation.
+            /// </summary>
+            public static bool CanTypeBeFinal(string type)
+            {
+                // Sessions can be final, lockouts cannot (they require a subsequent session to complete)
+                return type == SessionType;
+            }
         }
     }
 }

--- a/Study/ProtocolManager.cs
+++ b/Study/ProtocolManager.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿using BGC.IO;
+using BGC.Users;
+using BGC.Utility;
+using LightJson;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
-using LightJson;
-using BGC.IO;
-using BGC.Users;
 using System.Threading.Tasks;
+using Unity.Android.Gradle;
+using UnityEngine;
 
 namespace BGC.Study
 {
@@ -16,13 +18,62 @@ namespace BGC.Study
         SessionReady,
         SessionLimitExceeded,
         SessionElementLimitExceeded,
-        SessionFinished
+        SessionFinished,
+        Locked,
+        StepCompleted
+    }
+
+    public struct SequenceTime
+    {
+        public SequenceType type;
+        public int id;
+        public DateTime encounteredTime;
+        public DateTime completedTime;
+
+        public SequenceTime(SequenceType type, int id, DateTime encounteredTime, DateTime completedTime)
+        {
+            this.type = type;
+            this.id = id;
+            this.encounteredTime = encounteredTime;
+            this.completedTime = completedTime;
+        }
+
+        public SequenceTime(JsonObject json)
+        {
+            if (json["type"].IsString)
+            {
+                if (!Enum.TryParse(json["type"].AsString, out type))
+                {
+                    Debug.LogError($"Unknown SequenceType: {json["type"].AsString}");
+                    type = SequenceType.Session;
+                }
+            }
+            else
+            {
+                type = (SequenceType)json["type"].AsInteger;
+            }
+
+            id = json["id"].AsInteger;
+            encounteredTime = json["encounteredTime"].AsDateTime ?? DateTime.MinValue;
+            completedTime = json["completedTime"].AsDateTime ?? DateTime.MinValue;
+        }
+
+        public JsonObject ToJson()
+        {
+            return new JsonObject
+            {
+                { "type", type.ToString() },
+                { "id", id },
+                { "encounteredTime", encounteredTime },
+                { "completedTime", completedTime }
+            };
+        }
     }
 
     public static class ProtocolManager
     {
         private const string protocolDataDir = "Protocols";
-        public const int protocolDataVersion = 2;
+        public const int protocolDataVersion = 3;
 
         private static string loadedProtocolSet = "";
 
@@ -31,16 +82,63 @@ namespace BGC.Study
             public const string SessionNumber = "SessionNumber";
             public const string ElementNumber = "ElementNumber";
             public const string SessionInProgress = "SessionInProgress";
+            public const string SequenceTimes = "SequenceTimes";
+            public const string CurrentSequenceStartTime = "CurrentSequenceStartTime";
+            public const string SequenceIndex = "SequenceIndex";
         }
 
         public static Dictionary<string, Protocol> protocolDictionary = new Dictionary<string, Protocol>();
         public static Dictionary<int, Session> sessionDictionary = new Dictionary<int, Session>();
         public static Dictionary<int, SessionElement> sessionElementDictionary =
             new Dictionary<int, SessionElement>();
+        public static Dictionary<int, Lockout> lockoutDictionary = new Dictionary<int, Lockout>();
+        public static Dictionary<int, LockoutElement> lockoutElementDictionary =
+            new Dictionary<int, LockoutElement>();
 
         public static Protocol currentProtocol = null;
         public static Session currentSession = null;
         public static SessionElement currentSessionElement = null;
+        public static Lockout currentLockout = null;
+
+        public static IReadOnlyList<SequenceTime> SequenceTimes
+        {
+            get
+            {
+                JsonValue val = PlayerData.GetJsonValue(DataKeys.SequenceTimes);
+                if (val.IsJsonArray)
+                {
+                    List<SequenceTime> times = new();
+                    foreach (JsonValue v in val.AsJsonArray)
+                    {
+                        times.Add(new SequenceTime(v.AsJsonObject));
+                    }
+                    return times;
+                }
+                return new List<SequenceTime>();
+            }
+        }
+
+        public static void AddSequenceTime(SequenceTime sequenceTime)
+        {
+            JsonValue val = PlayerData.GetJsonValue(DataKeys.SequenceTimes);
+            JsonArray arr;
+            if (val.IsJsonArray)
+            {
+                arr = val.AsJsonArray;
+            }
+            else
+            {
+                arr = new JsonArray();
+            }
+            arr.Add(sequenceTime.ToJson());
+            PlayerData.SetJsonValue(DataKeys.SequenceTimes, arr);
+        }
+
+        public static DateTime CurrentSequenceStartTime
+        {
+            get => PlayerData.GetJsonValue(DataKeys.CurrentSequenceStartTime).AsDateTime ?? DateTime.MinValue;
+            set => PlayerData.SetJsonValue(DataKeys.CurrentSequenceStartTime, value);
+        }
 
         public static int nextSessionElementIndex = -1;
 
@@ -54,6 +152,12 @@ namespace BGC.Study
         {
             get => PlayerData.GetInt(DataKeys.SessionNumber, 0);
             set => PlayerData.SetInt(DataKeys.SessionNumber, value);
+        }
+
+        public static int SequenceIndex
+        {
+            get => PlayerData.GetInt(DataKeys.SequenceIndex, 0);
+            set => PlayerData.SetInt(DataKeys.SequenceIndex, value);
         }
 
         public static bool SessionInProgress
@@ -71,6 +175,227 @@ namespace BGC.Study
         private static PrepareNextElement prepareNextElement = null;
         private static MigrateProtocols migrateProtocols = null;
         private static ParseSessionElement parseSessionElement = null;
+
+        private static int GetSessionOrdinalAtSequenceIndex(int sequenceIndex)
+        {
+            if (currentProtocol == null || sequenceIndex < 0)
+            {
+                return 0;
+            }
+
+            int sessionCount = 0;
+            for (int i = 0; i <= sequenceIndex && i < currentProtocol.sequences.Count; i++)
+            {
+                if (currentProtocol.sequences[i].type == SequenceType.Session)
+                {
+                    sessionCount++;
+                }
+            }
+
+            return Math.Max(0, sessionCount - 1);
+        }
+
+        private static void EnsureSequenceIndexMigrated()
+        {
+            JsonValue sequenceIndexValue = PlayerData.GetJsonValue(DataKeys.SequenceIndex);
+            if (sequenceIndexValue.IsInteger)
+            {
+                SequenceIndex = sequenceIndexValue.AsInteger;
+                return;
+            }
+
+            int legacySessionIndex = SessionNumber;
+            int migratedIndex = GetSequenceIndexForSession(legacySessionIndex);
+            SequenceIndex = migratedIndex < 0 ? 0 : migratedIndex;
+        }
+
+        private static IProtocolSequenceMember ResolveSequenceMember(SequenceElement sequence)
+        {
+            return sequence.type switch
+            {
+                SequenceType.Session => sequence.Session,
+                SequenceType.Lockout => sequence.Lockout,
+                _ => null
+            };
+        }
+
+        private static ProtocolStatus SetSequence(int sequenceIndex, int element = 0)
+        {
+            currentSession = null;
+            currentSessionElement = null;
+            currentLockout = null;
+            nextSessionElementIndex = -1;
+
+            if (loadedProtocolSet == "" || currentProtocol == null)
+            {
+                return ProtocolStatus.Uninitialized;
+            }
+
+            if (sequenceIndex < 0)
+            {
+                return ProtocolStatus.InvalidProtocol;
+            }
+
+            if (sequenceIndex >= currentProtocol.sequences.Count)
+            {
+                SequenceIndex = currentProtocol.sequences.Count;
+                return ProtocolStatus.SessionFinished;
+            }
+
+            SequenceIndex = sequenceIndex;
+
+            SequenceElement sequence = currentProtocol.sequences[sequenceIndex];
+            IProtocolSequenceMember member = ResolveSequenceMember(sequence);
+            if (member == null)
+            {
+                return ProtocolStatus.InvalidProtocol;
+            }
+
+            member.OnEncountered();
+
+            if (sequence.type == SequenceType.Session)
+            {
+                currentSession = sequence.Session;
+                if (currentSession == null)
+                {
+                    return ProtocolStatus.InvalidProtocol;
+                }
+
+                SessionNumber = GetSessionOrdinalAtSequenceIndex(sequenceIndex);
+
+                if (element >= currentSession.Count)
+                {
+                    return ProtocolStatus.SessionElementLimitExceeded;
+                }
+
+                nextSessionElementIndex = element;
+                ElementNumber = element;
+
+                if (element == 0)
+                {
+                    SessionInProgress = false;
+                    CurrentSequenceStartTime = DateTime.Now;
+                }
+
+                ProtocolStatus status = member.CheckStatus();
+                if (status == ProtocolStatus.Locked)
+                {
+                    return ProtocolStatus.Locked;
+                }
+
+                return ProtocolStatus.SessionReady;
+            }
+
+            ProtocolStatus lockoutStatus = member.CheckStatus();
+            if (lockoutStatus == ProtocolStatus.Locked)
+            {
+                currentLockout = sequence.Lockout;
+                return ProtocolStatus.Locked;
+            }
+
+            if (lockoutStatus == ProtocolStatus.StepCompleted)
+            {
+                member.OnCompleted();
+                SequenceIndex = sequenceIndex + 1;
+            }
+
+            return ProtocolStatus.StepCompleted;
+        }
+
+        public static ProtocolStatus CheckSequenceStatus()
+        {
+            if (currentProtocol == null)
+            {
+                return ProtocolStatus.Uninitialized;
+            }
+
+            DateTime lockoutRelease = PlayerData.GetJsonValue("Lockout").AsDateTime ?? DateTime.MinValue;
+            if (DateTime.Now < lockoutRelease)
+            {
+                return ProtocolStatus.Locked;
+            }
+
+            EnsureSequenceIndexMigrated();
+
+            int seqIndex = SequenceIndex;
+
+            while (seqIndex < currentProtocol.sequences.Count)
+            {
+                SequenceElement sequence = currentProtocol.sequences[seqIndex];
+                IProtocolSequenceMember member = ResolveSequenceMember(sequence);
+
+                if (member == null)
+                {
+                    return ProtocolStatus.InvalidProtocol;
+                }
+
+                member.OnEncountered();
+                ProtocolStatus status = member.CheckStatus();
+
+                if (status == ProtocolStatus.Locked)
+                {
+                    if (sequence.type == SequenceType.Lockout)
+                    {
+                        currentLockout = sequence.Lockout;
+                    }
+                    return ProtocolStatus.Locked;
+                }
+
+                if (sequence.type == SequenceType.Session && status == ProtocolStatus.SessionReady)
+                {
+                    currentSession = sequence.Session;
+                    if (currentSession == null)
+                    {
+                        return ProtocolStatus.InvalidProtocol;
+                    }
+
+                    SessionNumber = GetSessionOrdinalAtSequenceIndex(seqIndex);
+
+                    nextSessionElementIndex = Math.Min(ElementNumber, currentSession.Count);
+                    if (nextSessionElementIndex >= currentSession.Count)
+                    {
+                        return ProtocolStatus.SessionElementLimitExceeded;
+                    }
+
+                    ElementNumber = nextSessionElementIndex;
+                    SessionInProgress = false;
+                    if (nextSessionElementIndex == 0)
+                    {
+                        CurrentSequenceStartTime = DateTime.Now;
+                    }
+
+                    return ProtocolStatus.SessionReady;
+                }
+
+                member.OnCompleted();
+                SequenceIndex = seqIndex + 1;
+                seqIndex = SequenceIndex;
+            }
+
+            return ProtocolStatus.SessionFinished;
+        }
+
+        public static ProtocolStatus AdvanceSequence(bool markCompletion = true)
+        {
+            if (currentProtocol != null && SequenceIndex < currentProtocol.sequences.Count)
+            {
+                IProtocolSequenceMember member = ResolveSequenceMember(currentProtocol.sequences[SequenceIndex]);
+                if (markCompletion)
+                {
+                    member?.OnCompleted();
+                }
+            }
+
+            SequenceIndex = SequenceIndex + 1;
+            nextSessionElementIndex = -1;
+            currentSession = null;
+            currentSessionElement = null;
+            currentLockout = null;
+            SessionInProgress = false;
+            ElementNumber = 0;
+
+            return CheckSequenceStatus();
+        }
 
         [Obsolete("Transition to string-based Protocol IDs when convenient")]
         public static void PrepareProtocol(
@@ -117,6 +442,88 @@ namespace BGC.Study
             }
         }
 
+        private static int GetSequenceIndexForSession(int sessionNumber)
+        {
+            if (currentProtocol == null) return -1;
+            int sessionCount = 0;
+            for (int i = 0; i < currentProtocol.sequences.Count; i++)
+            {
+                if (currentProtocol.sequences[i].type == SequenceType.Session)
+                {
+                    if (sessionCount == sessionNumber) return i;
+                    sessionCount++;
+                }
+            }
+            return -1;
+        }
+
+        public static ProtocolStatus CheckLockoutStatus()
+        {
+            currentLockout = null;
+
+            // 1. Old Time Lockout
+            DateTime lockoutRelease = PlayerData.GetJsonValue("Lockout").AsDateTime ?? DateTime.MinValue;
+            if (DateTime.Now < lockoutRelease)
+            {
+                return ProtocolStatus.Locked;
+            }
+
+            // 2. Old Password
+            if (currentSession != null)
+            {
+                string password = currentSession.GetPassword();
+                if (!string.IsNullOrEmpty(password))
+                {
+                    return ProtocolStatus.Locked;
+                }
+            }
+
+            // 3. New Lockouts
+            int currentSequenceIndex = GetSequenceIndexForSession(SessionNumber);
+            // If we can't find the session, we might be at the end or uninitialized.
+            // If SessionNumber is valid (checked elsewhere), this should be valid.
+            // If SessionNumber >= SessionCount, we are finished.
+            if (currentSequenceIndex == -1)
+            {
+                // If SessionNumber is valid but not found, it might be because we are past the last session?
+                // But GetSequenceIndexForSession iterates all sequences.
+                // If SessionNumber is valid, it should be found.
+                // Unless SessionNumber is out of bounds.
+                // TryUpdateProtocol checks bounds.
+                return ProtocolStatus.Uninitialized;
+            }
+
+            for (int i = currentSequenceIndex - 1; i >= 0; i--)
+            {
+                if (currentProtocol.sequences[i].type == SequenceType.Session) break;
+                
+                if (currentProtocol.sequences[i].type == SequenceType.Lockout)
+                {
+                    Lockout lockout = currentProtocol.sequences[i].Lockout;
+                    if (lockout != null)
+                    {
+                        foreach (LockoutElementID elementId in lockout)
+                        {
+                            LockoutElement element = elementId.Element;
+                            if (element == null)
+                            {
+                                Debug.LogError($"Lockout element is null for ID: {elementId.id}");
+                                continue;
+                            }
+
+                            if (element.CheckLockout(DateTime.Now, SequenceTimes))
+                            {
+                                currentLockout = lockout;
+                                return ProtocolStatus.Locked;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return ProtocolStatus.SessionReady;
+        }
+
         [Obsolete("Transition to string-based Protocol IDs when convenient")]
         public static ProtocolStatus TryUpdateProtocol(
             string protocolName,
@@ -129,8 +536,16 @@ namespace BGC.Study
                 if (protocolDictionary.ContainsKey(protocolID.ToString()))
                 {
                     currentProtocol = protocolDictionary[protocolID.ToString()];
+                    ElementNumber = sessionElementIndex;
 
-                    return SetSession(sessionIndex, sessionElementIndex);
+                    int seqIndex = GetSequenceIndexForSession(sessionIndex);
+                    if (seqIndex < 0)
+                    {
+                        return ProtocolStatus.SessionLimitExceeded;
+                    }
+
+                    SequenceIndex = seqIndex;
+                    return CheckSequenceStatus();
                 }
                 else
                 {
@@ -153,7 +568,16 @@ namespace BGC.Study
                 if (protocolDictionary.ContainsKey(protocolKey))
                 {
                     currentProtocol = protocolDictionary[protocolKey];
-                    return SetSession(sessionIndex, sessionElementIndex);
+                    ElementNumber = sessionElementIndex;
+
+                    int seqIndex = GetSequenceIndexForSession(sessionIndex);
+                    if (seqIndex < 0)
+                    {
+                        return ProtocolStatus.SessionLimitExceeded;
+                    }
+
+                    SequenceIndex = seqIndex;
+                    return CheckSequenceStatus();
                 }
                 else
                 {
@@ -167,37 +591,15 @@ namespace BGC.Study
 
         public static ProtocolStatus SetSession(int session, int element = 0)
         {
-            currentSession = null;
-            currentSessionElement = null;
-            nextSessionElementIndex = -1;
-
-            if (loadedProtocolSet == "")
-            {
-                return ProtocolStatus.Uninitialized;
-            }
-
-            if (!protocolDictionary.ContainsKey(currentProtocol.key))
-            {
-                return ProtocolStatus.InvalidProtocol;
-            }
-
-            if (session >= currentProtocol.Count)
+            int sequenceIndex = GetSequenceIndexForSession(session);
+            if (sequenceIndex < 0)
             {
                 return ProtocolStatus.SessionLimitExceeded;
             }
 
-            SessionNumber = session;
-            currentSession = currentProtocol[session];
-
-            if (element >= currentSession.Count)
-            {
-                return ProtocolStatus.SessionElementLimitExceeded;
-            }
-
-            //The next session element to run will be the current one
-            nextSessionElementIndex = element;
-
-            return ProtocolStatus.SessionReady;
+            SequenceIndex = sequenceIndex;
+            ElementNumber = element;
+            return SetSequence(sequenceIndex, element);
         }
 
         public static JsonValue GetEnvValue(string key, JsonValue defaultReturn = default(JsonValue))
@@ -305,18 +707,21 @@ namespace BGC.Study
                 return ProtocolStatus.Uninitialized;
             }
 
+            if (currentSession == null)
+            {
+                return ProtocolStatus.Uninitialized;
+            }
+
             if (nextSessionElementIndex == currentSession.Count)
             {
-                //In principle, this should only happen if an EndSessionElement was forgotten
-                ElementNumber = 0;
                 SessionInProgress = false;
-                ++SessionNumber;
-
                 sessionElementOverrun?.Invoke();
+
+                ProtocolStatus status = AdvanceSequence();
 
                 PlayerData.Save();
 
-                return ProtocolStatus.SessionFinished;
+                return status;
             }
 
             //This only happens when the last element was running
@@ -331,6 +736,12 @@ namespace BGC.Study
             prepareNextElement?.Invoke(resuming);
 
             await currentSessionElement.ExecuteElement(resuming);
+
+            if (nextSessionElementIndex == -1)
+            {
+                PlayerData.Save();
+                return CheckSequenceStatus();
+            }
 
             PlayerData.Save();
 
@@ -368,6 +779,28 @@ namespace BGC.Study
                 }
             }
 
+            Dictionary<int, int> lockoutElementRemapping = new Dictionary<int, int>();
+            Dictionary<string, int> lockoutElements = new Dictionary<string, int>();
+
+            foreach (KeyValuePair<int, LockoutElement> lockoutElement in lockoutElementDictionary)
+            {
+                JsonObject serializedElement = lockoutElement.Value.SerializeElement();
+                serializedElement.Remove(ProtocolKeys.LockoutElement.Id);
+
+                string serialization = serializedElement.ToString();
+                if (lockoutElements.ContainsKey(serialization))
+                {
+                    //Collision - Add it to be remapped
+                    int newID = lockoutElements[serialization];
+                    lockoutElementRemapping.Add(lockoutElement.Key, newID);
+                }
+                else
+                {
+                    //It's a different lockoutElement - Add it to the dictionary
+                    lockoutElements.Add(serialization, lockoutElement.Key);
+                }
+            }
+
             Dictionary<int, int> sessionRemapping = new Dictionary<int, int>();
             Dictionary<string, int> sessions = new Dictionary<string, int>();
 
@@ -401,16 +834,49 @@ namespace BGC.Study
                 }
             }
 
+            Dictionary<int, int> lockoutRemapping = new Dictionary<int, int>();
+            Dictionary<string, int> lockouts = new Dictionary<string, int>();
+
+            foreach (KeyValuePair<int, Lockout> lockout in lockoutDictionary)
+            {
+                //Apply Remapping To Lockouts
+                List<LockoutElementID> elementIDs = lockout.Value.lockoutElements;
+
+                for (int i = 0; i < elementIDs.Count; i++)
+                {
+                    if (lockoutElementRemapping.ContainsKey(elementIDs[i].id))
+                    {
+                        elementIDs[i] = new LockoutElementID(lockoutElementRemapping[elementIDs[i].id]);
+                    }
+                }
+
+                JsonObject serializedLockout = lockout.Value.SerializeLockout();
+                serializedLockout.Remove(Lockout.Keys.Id);
+
+                string serialization = serializedLockout.ToString();
+                if (lockouts.ContainsKey(serialization))
+                {
+                    //Collision - Add it to be remapped
+                    int newID = lockouts[serialization];
+                    lockoutRemapping.Add(lockout.Key, newID);
+                }
+                else
+                {
+                    //It's a different lockout - Add it to the dictionary
+                    lockouts.Add(serialization, lockout.Key);
+                }
+            }
+
             foreach (Protocol protocol in protocolDictionary.Values)
             {
                 //Apply Remapping To Protocols
-                List<SessionID> sessionIDs = protocol.sessions;
+                List<SequenceElement> sequences = protocol.sequences;
 
-                for (int i = 0; i < sessionIDs.Count; i++)
+                for (int i = 0; i < sequences.Count; i++)
                 {
-                    if (sessionRemapping.ContainsKey(sessionIDs[i].id))
+                    if (sequences[i].type == SequenceType.Session && sessionRemapping.ContainsKey(sequences[i].id))
                     {
-                        sessionIDs[i] = new SessionID(sessionRemapping[sessionIDs[i].id]);
+                        sequences[i] = new SequenceElement(sessionRemapping[sequences[i].id], SequenceType.Session);
                     }
                 }
             }
@@ -425,6 +891,18 @@ namespace BGC.Study
             foreach (int sessionID in sessionRemapping.Keys)
             {
                 sessionDictionary.Remove(sessionID);
+            }
+
+            //Remove eliminated LockoutElements
+            foreach (int lockoutElementID in lockoutElementRemapping.Keys)
+            {
+                lockoutElementDictionary.Remove(lockoutElementID);
+            }
+
+            //Remove eliminated Lockouts
+            foreach (int lockoutID in lockoutRemapping.Keys)
+            {
+                lockoutDictionary.Remove(lockoutID);
             }
         }
 
@@ -443,7 +921,9 @@ namespace BGC.Study
                     { ProtocolKeys.Version, protocolDataVersion },
                     { ProtocolKeys.Protocols, SerializeProtocols() },
                     { ProtocolKeys.Sessions, SerializeSessions() },
-                    { ProtocolKeys.SessionElements, SerializeSessionElements() }
+                    { ProtocolKeys.Lockouts, SerializeLockouts() },
+                    { ProtocolKeys.SessionElements, SerializeSessionElements() },
+                    { ProtocolKeys.LockoutElements, SerializeLockoutElements() }
                 },
                 pretty: false);
         }
@@ -475,7 +955,15 @@ namespace BGC.Study
 
                     DeserializeProtocols(jsonProtocols[ProtocolKeys.Protocols]);
                     DeserializeSessions(jsonProtocols[ProtocolKeys.Sessions]);
+                    if (jsonProtocols.ContainsKey(ProtocolKeys.Lockouts))
+                    {
+                        DeserializeLockouts(jsonProtocols[ProtocolKeys.Lockouts]);
+                    }
                     DeserializeSessionElements(jsonProtocols[ProtocolKeys.SessionElements]);
+                    if (jsonProtocols.ContainsKey(ProtocolKeys.LockoutElements))
+                    {
+                        DeserializeLockoutElements(jsonProtocols[ProtocolKeys.LockoutElements]);
+                    }
                 },
                 failCallback: () =>
                 {
@@ -483,6 +971,8 @@ namespace BGC.Study
                     protocolDictionary.Clear();
                     sessionDictionary.Clear();
                     sessionElementDictionary.Clear();
+                    lockoutDictionary.Clear();
+                    lockoutElementDictionary.Clear();
                 },
                 fileNotFoundCallback: () => loadedProtocolSet = previousLoadedProtocol);
         }
@@ -565,6 +1055,88 @@ namespace BGC.Study
             }
         }
 
+        public static JsonArray SerializeLockouts()
+        {
+            JsonArray lockouts = new JsonArray();
+
+            foreach (Lockout lockout in lockoutDictionary.Values)
+            {
+                lockouts.Add(lockout.SerializeLockout());
+            }
+
+            return lockouts;
+        }
+
+        public static void DeserializeLockouts(JsonArray lockouts)
+        {
+            lockoutDictionary.Clear();
+
+            foreach (JsonObject lockoutData in lockouts)
+            {
+                Lockout lockout = new Lockout(lockoutData);
+
+                lockoutDictionary.Add(lockout.id, lockout);
+            }
+        }
+
+        public static JsonArray SerializeLockoutElements()
+        {
+            JsonArray lockoutElements = new JsonArray();
+
+            foreach (LockoutElement element in lockoutElementDictionary.Values)
+            {
+                lockoutElements.Add(element.SerializeElement());
+            }
+
+            return lockoutElements;
+        }
+
+        public delegate LockoutElement ParseLockoutElement(JsonObject lockoutElement);
+        private static ParseLockoutElement parseLockoutElement = null;
+
+        public static void RegisterLockoutElementParser(ParseLockoutElement parseLockoutElement)
+        {
+            ProtocolManager.parseLockoutElement = parseLockoutElement;
+        }
+
+        public static void DeserializeLockoutElements(JsonArray elements)
+        {
+            lockoutElementDictionary.Clear();
+
+            foreach (JsonObject element in elements)
+            {
+                LockoutElement parsedElement = parseLockoutElement?.Invoke(element);
+
+                if (parsedElement == null)
+                {
+                    string type = element[ProtocolKeys.LockoutElement.Type].AsString;
+                    switch (type)
+                    {
+                        case "FixedTime":
+                            parsedElement = new FixedTimeLockout(element);
+                            break;
+                        case "Password":
+                            parsedElement = new PasswordLockout(element);
+                            break;
+                        case "Window":
+                            parsedElement = new WindowLockout(element);
+                            break;
+                        default:
+                            Debug.LogError($"Unknown LockoutElement Type: {type}");
+                            break;
+                    }
+                }
+
+                if (parsedElement == null)
+                {
+                    Debug.LogError($"Failed to parse LockoutElement: {element.ToString()}");
+                    continue;
+                }
+
+                lockoutElementDictionary.Add(parsedElement.id, parsedElement);
+            }
+        }
+
         [Obsolete("Transition to string-based Protocol IDs")]
         public static string GetProtocolName(int protocolID) => GetProtocolName(protocolID.ToString());
 
@@ -584,10 +1156,14 @@ namespace BGC.Study
             protocolDictionary.Clear();
             sessionDictionary.Clear();
             sessionElementDictionary.Clear();
+            lockoutDictionary.Clear();
+            lockoutElementDictionary.Clear();
 
             Protocol.HardClear();
             Session.HardClear();
             SessionElement.HardClear();
+            Lockout.HardClear();
+            LockoutElement.HardClear();
         }
 
         public static void DeleteProtocol(string protocolSetName)


### PR DESCRIPTION
Introduces version 3 of protocols which remove lockouts from sessions and start/end session elements and instead uses specific lockout elements.

The session list is replaced with a sequence list. The sequence can reference session or lockout elements, allowing for straight-forward and flexible configuration of when sessions and lockouts occur.

Adds "Windowed Lockout" which allows N sessions within a time window before locking out, with support for a minimum time between sessions regardless of the window state.