### PR TITLE
Fix negative sampleCount crash in StreamWindower when stream is short…

### DIFF
--- a/Audio/Filters/StreamWindower.cs
+++ b/Audio/Filters/StreamWindower.cs
@@ -63,13 +63,15 @@ namespace BGC.Audio.Filters
         {
             if (openingSmoothingSamples + closingSmoothingSamples > ChannelSamples)
             {
-                //Requested smoothing samples exceeded remaining stream length
+                //Requested smoothing samples exceeded remaining stream length.
+                //Proportionally shrink both skirts so they fill exactly the available
+                //samples, preserving the requested opening/closing ratio. This generalizes
+                //the old single-function clamp (Math.Min(smoothingSamples, ChannelSamples / 2))
+                //to asymmetric windows and is well-defined down to ChannelSamples == 0.
                 int totalSmoothingSamples = openingSmoothingSamples + closingSmoothingSamples;
-                int excessSamples = totalSmoothingSamples - ChannelSamples;
 
-                //Allocate reduced smoothing samples based on requested percentage
-                openingSmoothingSamples -= (int)Math.Round(
-                    excessSamples * (openingSmoothingSamples / (double)totalSmoothingSamples));
+                openingSmoothingSamples = (int)Math.Round(
+                    ChannelSamples * (openingSmoothingSamples / (double)totalSmoothingSamples));
                 closingSmoothingSamples = ChannelSamples - openingSmoothingSamples;
             }
 

--- a/Audio/Filters/StreamWindower.cs
+++ b/Audio/Filters/StreamWindower.cs
@@ -65,7 +65,7 @@ namespace BGC.Audio.Filters
             {
                 //Requested smoothing samples exceeded remaining stream length
                 int totalSmoothingSamples = openingSmoothingSamples + closingSmoothingSamples;
-                int excessSamples = ChannelSamples - totalSmoothingSamples;
+                int excessSamples = totalSmoothingSamples - ChannelSamples;
 
                 //Allocate reduced smoothing samples based on requested percentage
                 openingSmoothingSamples -= (int)Math.Round(

--- a/Audio/Windowing.cs
+++ b/Audio/Windowing.cs
@@ -25,6 +25,14 @@ namespace BGC.Audio
             Function function,
             int sampleCount)
         {
+            if (sampleCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sampleCount),
+                    sampleCount,
+                    "Half-window sample count must be non-negative.");
+            }
+
             switch (function)
             {
                 case Function.Hamming: return HammingHalfWindow(sampleCount);
@@ -45,6 +53,14 @@ namespace BGC.Audio
             Function function,
             int sampleCount)
         {
+            if (sampleCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sampleCount),
+                    sampleCount,
+                    "Half-window sample count must be non-negative.");
+            }
+
             switch (function)
             {
                 case Function.Hamming: return HammingHalfWindow64(sampleCount);
@@ -463,6 +479,13 @@ namespace BGC.Audio
 
         private static float[] HammingHalfWindow(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new float[] { 1f };
+            }
+
             const float alpha = 0.54f;
             const float beta = 1f - alpha;
 
@@ -480,6 +503,13 @@ namespace BGC.Audio
 
         private static float[] HannHalfWindow(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new float[] { 1f };
+            }
+
             const float alpha = 0.5f;
             const float beta = 1f - alpha;
 
@@ -497,6 +527,13 @@ namespace BGC.Audio
 
         private static float[] BlackmanHarrisHalfWindow(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new float[] { 1f };
+            }
+
             const double a0 = 0.35875;
             const double a1 = 0.48829;
             const double a2 = 0.14128;
@@ -532,6 +569,13 @@ namespace BGC.Audio
 
         private static float[] LinearHalfWindow(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (i / (sampleCount - 1)) that would yield NaN.
+                return new float[] { 1f };
+            }
+
             float[] window = new float[sampleCount];
 
             float limit = sampleCount - 1;
@@ -563,6 +607,13 @@ namespace BGC.Audio
 
         private static double[] HammingHalfWindow64(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new double[] { 1.0 };
+            }
+
             const double alpha = 0.54;
             const double beta = 1.0 - alpha;
 
@@ -580,6 +631,13 @@ namespace BGC.Audio
 
         private static double[] HannHalfWindow64(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new double[] { 1.0 };
+            }
+
             const double alpha = 0.5;
             const double beta = 1.0 - alpha;
 
@@ -597,6 +655,13 @@ namespace BGC.Audio
 
         private static double[] BlackmanHarrisHalfWindow64(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (Math.PI / (sampleCount - 1)) that would yield NaN.
+                return new double[] { 1.0 };
+            }
+
             const double a0 = 0.35875;
             const double a1 = 0.48829;
             const double a2 = 0.14128;
@@ -632,6 +697,13 @@ namespace BGC.Audio
 
         private static double[] LinearHalfWindow64(int sampleCount)
         {
+            if (sampleCount == 1)
+            {
+                //A single-sample skirt has no ramp; treat it as fully open to avoid the
+                //divide-by-zero (i / (sampleCount - 1)) that would yield NaN.
+                return new double[] { 1.0 };
+            }
+
             double[] window = new double[sampleCount];
 
             double limit = sampleCount - 1;

--- a/Editor/Tests/Audio/StreamWindowerTests.cs
+++ b/Editor/Tests/Audio/StreamWindowerTests.cs
@@ -1,0 +1,117 @@
+using System;
+using NUnit.Framework;
+using BGC.Audio;
+using BGC.Audio.Filters;
+using BGC.Audio.Synthesis;
+
+namespace BGC.Tests
+{
+    /// <summary>
+    /// Regression tests for <see cref="StreamWindower"/> windowing streams that are
+    /// shorter than the requested smoothing skirts.
+    ///
+    /// Background: a stream shorter than (openingSkirt + closingSkirt) must have its
+    /// skirts shrunk to fit. An inverted sign in that reduction (regressed when the
+    /// single- and two-function windower constructors were consolidated) drove the
+    /// closing skirt negative, so <c>Windowing.GetHalfWindow</c> attempted
+    /// <c>new float[negative]</c> and threw a message-less <see cref="OverflowException"/>.
+    /// The repro in PART is the standard (non-target) interval of a 4-interval
+    /// "tone in quiet" assessment, whose StimulusCollection produces an empty
+    /// (ChannelSamples == 0) stream that the Windower transform then tried to window.
+    /// </summary>
+    public class StreamWindowerTests
+    {
+        private const int SkirtSamples = 441; // 10 ms @ 44.1 kHz, the PART default
+
+        // An empty (0-sample) stream is the exact PART repro: it must window without
+        // throwing and remain a 0-length stream.
+        [Test]
+        public void WindowingEmptyStreamDoesNotThrow()
+        {
+            IBGCStream stream = new SilenceStream(1, 0);
+
+            IBGCStream windowed = null;
+            Assert.DoesNotThrow(() =>
+            {
+                windowed = stream.Window(Windowing.Function.Hamming, SkirtSamples);
+            });
+
+            Assert.AreEqual(0, windowed.ChannelSamples);
+
+            float[] buffer = new float[8];
+            Assert.AreEqual(0, windowed.Read(buffer, 0, buffer.Length));
+        }
+
+        // Streams shorter than the combined skirts must window without throwing and
+        // produce only finite, attenuated (|x| <= source amplitude) samples.
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(99)]   // odd
+        [TestCase(100)]  // even
+        [TestCase(881)]  // one less than 2 * SkirtSamples
+        public void WindowingShortStreamProducesFiniteSamples(int channelSamples)
+        {
+            IBGCStream stream = new SineWave(1.0, 1000.0)
+                .Truncate(totalChannelSamples: channelSamples)
+                .Window(Windowing.Function.Hamming, SkirtSamples);
+
+            Assert.AreEqual(channelSamples, stream.ChannelSamples);
+
+            float[] buffer = new float[channelSamples];
+            int read = stream.Read(buffer, 0, buffer.Length);
+            Assert.AreEqual(channelSamples, read);
+
+            for (int i = 0; i < read; i++)
+            {
+                Assert.IsFalse(float.IsNaN(buffer[i]), $"NaN at sample {i}");
+                Assert.IsFalse(float.IsInfinity(buffer[i]), $"Infinity at sample {i}");
+                Assert.LessOrEqual(Math.Abs(buffer[i]), 1.0f + 1e-4f, $"Sample {i} not attenuated");
+            }
+        }
+
+        // Streams long enough for the requested skirts are windowed unchanged
+        // (no silent reshaping of ordinary stimuli).
+        [Test]
+        public void WindowingLongStreamKeepsRequestedSkirts()
+        {
+            const int channelSamples = 22050; // 500 ms, far longer than 2 * SkirtSamples
+
+            IBGCStream stream = new SineWave(1.0, 1000.0)
+                .Truncate(totalChannelSamples: channelSamples)
+                .Window(Windowing.Function.Hamming, SkirtSamples);
+
+            Assert.AreEqual(channelSamples, stream.ChannelSamples);
+
+            float[] buffer = new float[channelSamples];
+            int read = stream.Read(buffer, 0, buffer.Length);
+            Assert.AreEqual(channelSamples, read);
+
+            // The opening skirt ramps from ~0; the steady middle reaches full amplitude.
+            float maxMagnitude = 0f;
+            for (int i = 0; i < read; i++)
+            {
+                maxMagnitude = Math.Max(maxMagnitude, Math.Abs(buffer[i]));
+            }
+
+            Assert.Greater(maxMagnitude, 0.99f, "Full-amplitude region was unexpectedly attenuated");
+        }
+
+        // GetHalfWindow / GetHalfWindow64 should reject a negative count loudly rather
+        // than surfacing a message-less OverflowException from new float[negative].
+        [Test]
+        public void GetHalfWindowRejectsNegativeSampleCount()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => Windowing.GetHalfWindow(Windowing.Function.Hamming, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => Windowing.GetHalfWindow64(Windowing.Function.Hamming, -1));
+        }
+
+        [Test]
+        public void GetHalfWindowAllowsZeroSampleCount()
+        {
+            Assert.AreEqual(0, Windowing.GetHalfWindow(Windowing.Function.Hamming, 0).Length);
+            Assert.AreEqual(0, Windowing.GetHalfWindow64(Windowing.Function.Hamming, 0).Length);
+        }
+    }
+}

--- a/Editor/Tests/Audio/StreamWindowerTests.cs.meta
+++ b/Editor/Tests/Audio/StreamWindowerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce511feb5918fa54abb60e0d3e009e5f


### PR DESCRIPTION
StreamWindower.CalculateWindows: fixed inverted sign on excessSamples — when the stream is shorter than the combined windowing skirts, the skirts were being enlarged instead of reduced, producing a negative closingSmoothingSamples that crashed HammingHalfWindow with a negative array size