### PR TITLE
Add AppendTypeProvider hook + overridable StimulusView dropdown choices

### DIFF
--- a/Parameters/IPropertyGroup.cs
+++ b/Parameters/IPropertyGroup.cs
@@ -1001,13 +1001,9 @@ namespace BGC.Parameters
 
         public static Type GetDefaultSelectionType(this PropertyInfo info)
         {
-            foreach (AppendSelectionAttribute selectionAttribute in
-                info.GetCustomAttributes<AppendSelectionAttribute>())
+            foreach (Type type in info.GetSelectionTypes())
             {
-                foreach (Type type in selectionAttribute.selectionTypes)
-                {
-                    return type;
-                }
+                return type;
             }
 
             throw new Exception($"Failed to locate a Selection for property: {info}");
@@ -1015,8 +1011,24 @@ namespace BGC.Parameters
 
         /// <summary>
         /// Returns the valid Types for this PropertyGroup.
+        /// When the property carries an <see cref="AppendTypeProviderAttribute"/>, the provider
+        /// supplies the list; otherwise the static attribute-declared types are returned.
         /// </summary>
         public static IEnumerable<Type> GetListAdditionTypes(this PropertyInfo propertyInfo)
+        {
+            AppendTypeProviderAttribute providerAttribute =
+                propertyInfo.GetCustomAttribute<AppendTypeProviderAttribute>();
+
+            return providerAttribute != null
+                ? providerAttribute.GetProvider().GetListAdditionTypes(propertyInfo)
+                : propertyInfo.GetAttributeListAdditionTypes();
+        }
+
+        /// <summary>
+        /// Returns the Types declared via <see cref="AppendAdditionAttribute"/> only,
+        /// ignoring any <see cref="AppendTypeProviderAttribute"/> on the property.
+        /// </summary>
+        public static IEnumerable<Type> GetAttributeListAdditionTypes(this PropertyInfo propertyInfo)
         {
             foreach (AppendAdditionAttribute additionAttribute in
                 propertyInfo.GetCustomAttributes<AppendAdditionAttribute>())
@@ -1030,8 +1042,24 @@ namespace BGC.Parameters
 
         /// <summary>
         /// Returns the valid Types for this PropertyGroup.
+        /// When the property carries an <see cref="AppendTypeProviderAttribute"/>, the provider
+        /// supplies the list; otherwise the static attribute-declared types are returned.
         /// </summary>
         public static IEnumerable<Type> GetSelectionTypes(this PropertyInfo propertyInfo)
+        {
+            AppendTypeProviderAttribute providerAttribute =
+                propertyInfo.GetCustomAttribute<AppendTypeProviderAttribute>();
+
+            return providerAttribute != null
+                ? providerAttribute.GetProvider().GetSelectionTypes(propertyInfo)
+                : propertyInfo.GetAttributeSelectionTypes();
+        }
+
+        /// <summary>
+        /// Returns the Types declared via <see cref="AppendSelectionAttribute"/> only,
+        /// ignoring any <see cref="AppendTypeProviderAttribute"/> on the property.
+        /// </summary>
+        public static IEnumerable<Type> GetAttributeSelectionTypes(this PropertyInfo propertyInfo)
         {
             foreach (AppendSelectionAttribute selectionAttribute in
                 propertyInfo.GetCustomAttributes<AppendSelectionAttribute>())

--- a/Parameters/ParameterAttributes/AppendTypeProviderAttribute.cs
+++ b/Parameters/ParameterAttributes/AppendTypeProviderAttribute.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace BGC.Parameters
+{
+    /// <summary>
+    /// Supplies the full, ordered selection/addition type list for a property at runtime.
+    /// When a property carries an <see cref="AppendTypeProviderAttribute"/>, the provider
+    /// replaces the static <see cref="AppendSelectionAttribute"/>/<see cref="AppendAdditionAttribute"/>
+    /// lists as the source consumed by
+    /// <see cref="PropertyGroupExtensions.GetSelectionTypes"/> and
+    /// <see cref="PropertyGroupExtensions.GetListAdditionTypes"/> (and therefore by UI dropdowns,
+    /// deserialization type matching, and default selection). A provider that wants to merge with
+    /// the attribute-declared types can read them via
+    /// <see cref="PropertyGroupExtensions.GetAttributeSelectionTypes"/> /
+    /// <see cref="PropertyGroupExtensions.GetAttributeListAdditionTypes"/>.
+    /// </summary>
+    public interface IAppendTypeProvider
+    {
+        IEnumerable<Type> GetSelectionTypes(PropertyInfo property);
+
+        IEnumerable<Type> GetListAdditionTypes(PropertyInfo property);
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AppendTypeProviderAttribute : Attribute
+    {
+        public readonly Type providerType;
+
+        private IAppendTypeProvider cachedProvider;
+
+        public AppendTypeProviderAttribute(Type providerType)
+        {
+            if (!typeof(IAppendTypeProvider).IsAssignableFrom(providerType))
+            {
+                throw new ArgumentException($"ProviderType must implement IAppendTypeProvider: {providerType}");
+            }
+
+            this.providerType = providerType;
+        }
+
+        public IAppendTypeProvider GetProvider() =>
+            cachedProvider ??= (IAppendTypeProvider)Activator.CreateInstance(providerType);
+    }
+}

--- a/Parameters/ParameterAttributes/AppendTypeProviderAttribute.cs.meta
+++ b/Parameters/ParameterAttributes/AppendTypeProviderAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0d29ca84d32e7249b3dc0eb5c408908

--- a/Parameters/View/StimulusView.cs
+++ b/Parameters/View/StimulusView.cs
@@ -41,6 +41,22 @@ namespace BGC.Parameters.View
 
         protected virtual Type FallbackSetupMethodsClass => null;
 
+        /// <summary>
+        /// The types offered in a property-group selection dropdown, in display order.
+        /// Override to filter or reorder the user-facing choices. <paramref name="currentType"/>
+        /// is the type currently assigned to the property; overrides must keep it selectable so
+        /// existing data remains editable. This only affects dropdown construction —
+        /// deserialization always uses <see cref="PropertyGroupExtensions.GetSelectionTypes"/>.
+        /// </summary>
+        protected virtual IEnumerable<Type> GetSelectionChoiceTypes(PropertyInfo property, Type currentType) =>
+            property.GetSelectionTypes();
+
+        /// <summary>
+        /// Display title for a choice in a selection dropdown. Override to annotate titles
+        /// (e.g. deprecation markers) without affecting serialization names.
+        /// </summary>
+        protected virtual string GetSelectionChoiceTitle(Type type) => type.GetSelectionTitle();
+
         #region Interface Colors
 
         protected virtual Color PropertyGroupDropdownNormalBG { get; } = Color.white;
@@ -283,13 +299,13 @@ namespace BGC.Parameters.View
 
 
             List<Dropdown.OptionData> propertyGroupChoices = new List<Dropdown.OptionData>();
-            Type[] propertyGroupChoiceTypes = property.GetSelectionTypes().ToArray();
+            Type[] propertyGroupChoiceTypes = GetSelectionChoiceTypes(property, propertyGroup.GetType()).ToArray();
 
             int currentDataIndex = 0;
 
             foreach (Type type in propertyGroupChoiceTypes)
             {
-                propertyGroupChoices.Add(new Dropdown.OptionData(type.GetSelectionTitle()));
+                propertyGroupChoices.Add(new Dropdown.OptionData(GetSelectionChoiceTitle(type)));
 
                 if (type == propertyGroup.GetType())
                 {
@@ -561,13 +577,13 @@ namespace BGC.Parameters.View
                 //Build class-selection dropdown
 
                 List<Dropdown.OptionData> propertyGroupChoices = new List<Dropdown.OptionData>();
-                Type[] propertyGroupChoiceTypes = property.GetSelectionTypes().ToArray();
+                Type[] propertyGroupChoiceTypes = GetSelectionChoiceTypes(property, propertyGroup.GetType()).ToArray();
 
                 int currentDataIndex = 0;
 
                 foreach (Type type in propertyGroupChoiceTypes)
                 {
-                    propertyGroupChoices.Add(new Dropdown.OptionData(type.GetSelectionTitle()));
+                    propertyGroupChoices.Add(new Dropdown.OptionData(GetSelectionChoiceTitle(type)));
 
                     if (type == propertyGroup.GetType())
                     {

--- a/Study/ProtocolManager.cs
+++ b/Study/ProtocolManager.cs
@@ -1,4 +1,4 @@
-﻿using BGC.IO;
+using BGC.IO;
 using BGC.Users;
 using LightJson;
 using System;
@@ -147,7 +147,7 @@ namespace BGC.Study
         public const string DefaultTrackHubSceneName = "TrackHubScene";
 
         /// <summary>
-        /// Scene name loaded for <see cref="MenuManager.WindowState.TrackHub"/>. Set from the
+        /// Scene name loaded when navigating to the track hub (MenuManager.ShowTrackHub). Set from the
         /// optional top-level "TrackHubSceneName" field of the protocol-set JSON; falls back to
         /// <see cref="DefaultTrackHubSceneName"/> when the field is absent.
         /// </summary>


### PR DESCRIPTION
## Summary

Additive parameter-system hooks that let a consuming project (PART) supply property-group selection/addition type lists at runtime and customize selection dropdowns, **without changing behavior for any property that does not opt in**. This is the shared-library half of PART''s task-system refactor (registry-driven, self-registering tasks); the PART branch depends on this merging first.

> ⚠️ **Shared-library change — flagged for lab-wide review.** BGC_Tools is consumed by multiple lab projects. This PR is designed to be provably inert for all of them (see "Why this is safe" below), but please review with sibling repos in mind.

## What changed

- **`Parameters/ParameterAttributes/AppendTypeProviderAttribute.cs`** (new): `IAppendTypeProvider { GetSelectionTypes(PropertyInfo); GetListAdditionTypes(PropertyInfo); }` plus `[AppendTypeProvider(typeof(Provider))]`. The attribute validates that the provider type implements the interface (throws otherwise) and caches the instance.
- **`Parameters/IPropertyGroup.cs`**: `GetSelectionTypes` / `GetListAdditionTypes` now check for an `AppendTypeProviderAttribute`; when present the provider supplies the list, otherwise they delegate to the new `GetAttributeSelectionTypes` / `GetAttributeListAdditionTypes`, which contain the **verbatim previous bodies**. A provider can merge with the static lists by calling those `GetAttribute*` helpers. `GetDefaultSelectionType` was rerouted over `GetSelectionTypes()` (same first element, same order).
- **`Parameters/View/StimulusView.cs`**: two new `virtual` hooks — `GetSelectionChoiceTypes(property, currentType)` (default `property.GetSelectionTypes()`) and `GetSelectionChoiceTitle(type)` (default `type.GetSelectionTitle()`) — used when building class-selection dropdowns. Lets a subclass filter/reorder/annotate the user-facing choices; deserialization still goes through `GetSelectionTypes()` unchanged.
- **`Study/ProtocolManager.cs`**: doc-comment update only (a `<see cref>` that referenced a PART enum being removed), plus an incidental UTF-8 BOM strip on line 1.

## Why this is safe for sibling repos

- A property with no `AppendTypeProviderAttribute` (i.e. every property in every existing repo) takes the fallback path, which is the original code unchanged → byte-identical selection/addition lists, deserialization matching, and default selection.
- The provider path is unreachable without the new attribute.
- The StimulusView hooks are `virtual` with defaults equal to the prior inline behavior; existing subclasses that don''t override them are unaffected.
- No public API removed or renamed; only additions and behavior-preserving refactors.

## Validation

Compiles and runs as the BGC_Tools submodule inside PART; PART''s full EditMode suite is green except a known, pre-existing environmental baseline (audio/midi/synthesis fixtures) unrelated to these files. The PART golden/round-trip tests (which exercise `GetSelectionTypes`/`GetListAdditionTypes` and deserialization heavily) pass, confirming the fallback path is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)