### PR TITLE
Recursively default a missing property group's nested children

### DIFF
--- a/Editor/Tests/Parameters.meta
+++ b/Editor/Tests/Parameters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6ad078845be0904aba0cac330fb7a09
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs
+++ b/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs
@@ -1,0 +1,70 @@
+using BGC.Parameters;
+using LightJson;
+using NUnit.Framework;
+
+namespace BGC.Tests
+{
+    /// <summary>
+    /// Regression tests for property-group defaulting during deserialization.
+    ///
+    /// A property-group key that is absent from the serialized data must be constructed as a
+    /// fully-defaulted group, including its own nested [AppendSelection] children. Previously
+    /// the absent-key path only called Build() (which initializes field properties but does
+    /// not recurse into nested property groups), so a defaulted group's children were left
+    /// null -- which downstream code then dereferenced (NullReferenceException). The present
+    /// key path did not have this problem because it followed Build() with Deserialize().
+    /// </summary>
+    public class PropertyGroupDefaultingTests
+    {
+        // ---- Minimal self-contained property-group hierarchy ----
+        // Root -> Child (AppendSelection) -> Grandchild (AppendSelection)
+
+        [PropertyGroupTitle("Test Grandchild")]
+        private interface ITestGrandchild : IPropertyGroup { }
+
+        [PropertyChoiceTitle("Default Grandchild")]
+        private class TestGrandchild : CommonPropertyGroup, ITestGrandchild { }
+
+        [PropertyGroupTitle("Test Child")]
+        private interface ITestChild : IPropertyGroup
+        {
+            ITestGrandchild Grandchild { get; }
+        }
+
+        [PropertyChoiceTitle("Default Child")]
+        private class TestChild : CommonPropertyGroup, ITestChild
+        {
+            [AppendSelection(typeof(TestGrandchild))]
+            public ITestGrandchild Grandchild { get; set; }
+        }
+
+        private class TestRoot : CommonPropertyGroup
+        {
+            [AppendSelection(typeof(TestChild))]
+            public ITestChild Child { get; set; }
+        }
+
+        [Test]
+        public void AbsentPropertyGroupKey_DefaultsNestedChildrenRecursively()
+        {
+            IPropertyGroup root = new TestRoot();
+            root.InitializeProperties();
+
+            // Deserialize with the "Child" key absent. Child must be default-constructed,
+            // and -- the regression under test -- its own nested "Grandchild" must be
+            // recursively defaulted rather than left null.
+            root.Internal_RawDeserialize(new JsonObject());
+
+            TestRoot typedRoot = (TestRoot)root;
+
+            Assert.IsNotNull(
+                typedRoot.Child,
+                "An absent nested property group should be default-constructed.");
+
+            Assert.IsNotNull(
+                typedRoot.Child.Grandchild,
+                "A defaulted property group's own nested [AppendSelection] child must be " +
+                "recursively defaulted, not left null.");
+        }
+    }
+}

--- a/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs.meta
+++ b/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f08c203149b4120419b27ab44b88b264

--- a/Parameters/IPropertyGroup.cs
+++ b/Parameters/IPropertyGroup.cs
@@ -422,9 +422,9 @@ namespace BGC.Parameters
         // initializes field properties and applies append-selection defaults; it does NOT
         // recurse into the new group's own nested property groups, leaving them null. The
         // present-key path avoids this because it follows Build() with Deserialize(), whose
-        // Internal_RawDeserialize recursively defaults missing children. To keep "missing
-        // key" behave identically to "present but empty", we run the same recursion here on
-        // an empty object. (Internal_RawDeserialize rather than Deserialize, because the
+        // Internal_RawDeserialize recursively defaults missing children. So that a missing
+        // key behaves identically to a present-but-empty one, we run the same recursion here
+        // on an empty object. (Internal_RawDeserialize rather than Deserialize, because the
         // latter logs a spurious error for the absent "Type" field.)
         public static void ConstructNewInternalPropertyGroup(
             this IPropertyGroup container,

--- a/Parameters/IPropertyGroup.cs
+++ b/Parameters/IPropertyGroup.cs
@@ -418,13 +418,25 @@ namespace BGC.Parameters
             }
         }
 
+        // When a property-group key is absent we construct its default. Build() only
+        // initializes field properties and applies append-selection defaults; it does NOT
+        // recurse into the new group's own nested property groups, leaving them null. The
+        // present-key path avoids this because it follows Build() with Deserialize(), whose
+        // Internal_RawDeserialize recursively defaults missing children. To keep "missing
+        // key" behave identically to "present but empty", we run the same recursion here on
+        // an empty object. (Internal_RawDeserialize rather than Deserialize, because the
+        // latter logs a spurious error for the absent "Type" field.)
         public static void ConstructNewInternalPropertyGroup(
             this IPropertyGroup container,
-            PropertyInfo property) => property.GetDefaultSelectionType().Build(container, property);
+            PropertyInfo property) =>
+            property.GetDefaultSelectionType().Build(container, property)
+                .Internal_RawDeserialize(new JsonObject());
 
         public static void ConstructNewInlinePropertyGroup(
             this IPropertyGroup container,
-            PropertyInfo property) => property.PropertyType.Build(container, property);
+            PropertyInfo property) =>
+            property.PropertyType.Build(container, property)
+                .Internal_RawDeserialize(new JsonObject());
 
         public static void DeserializeInternalPropertyGroup(
             this IPropertyGroup container,


### PR DESCRIPTION
## Problem

When a property-group key is **absent** during deserialization, the system is supposed to construct the default — but the default path didn't recurse into the new group's own nested `[AppendSelection]` properties, leaving them **null**.

- **Present key:** `Build().Deserialize(data)` — `Deserialize` → `Internal_RawDeserialize` recursively defaults missing children. ✅
- **Absent key:** `ConstructNewInternalPropertyGroup` = `Build()` only — nested children left null. ❌

`Build()` only initializes *field* properties and applies append-selection defaults; it does not construct nested property groups. So a defaulted-because-absent group came back with null children, even though "missing parameter → default" is supposed to make null impossible.

### Impact
A battery that omits a property group — or **predates a newly-added nested group** (e.g. an adaptive algorithm's `Time Constraint`) — deserializes a group whose children (`TimeConstraint` / `StreakBehavior` / `TerminationRule`, …) are null. Code that uses them (e.g. `SimpleStaircaseDifficultyAlgorithm.Initialize()` → `TimeConstraint.Initialize()`) then throws `NullReferenceException`. In one observed case this fired inside a scene-load bootstrap coroutine and left the Editor's play-mode transition unresponsive.

This affects **any** task with nested `[AppendSelection]` groups, not one specific task.

## Fix

Make the absent-key path run the same recursion as the present-key path, on an empty object, so "missing key" behaves identically to "present but empty" and all nested children are defaulted:

```csharp
property.GetDefaultSelectionType().Build(container, property)
    .Internal_RawDeserialize(new JsonObject());
```

`Internal_RawDeserialize` is used rather than `Deserialize` to skip the spurious `"Type data not present!"` error for the absent type field. Only the two `ConstructNew*PropertyGroup` methods change; they are called only from the missing-key branch of `Internal_RawDeserialize`, so blast radius is limited to defaulting.

## Validation

Deserialized an XRPsys CSF stage with **no algorithm key**. Before: the defaulted algorithm's nested groups were null. After:

```
Algorithm = CSFSimpleStaircaseAlgorithm
  TimeConstraint  = AlgorithmNoTimeConstraint
  StreakBehavior  = NoStreak
  TerminationRule = ReversalCountTermination
```

All nested children now default instead of being null.

## Notes for reviewers
- No automated test is included yet (no existing `Parameters` test folder in this repo). A regression test would build a property group with a nested `[AppendSelection]`, deserialize JSON omitting the nested key, and assert the child is non-null. Happy to add one if you want it in this PR.
- Consumer-side note: the dependent project (PART) also has a defensive null-guard on `TimeConstraint` in its adaptive algorithms as immediate insurance; this PR is the root fix and makes that guard redundant once the submodule pointer is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
