### PR TITLE
Don't error on a missing item title during default construction

### DIFF
--- a/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs
+++ b/Editor/Tests/Parameters/PropertyGroupDefaultingTests.cs
@@ -1,6 +1,7 @@
 using BGC.Parameters;
 using LightJson;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace BGC.Tests
 {
@@ -65,6 +66,54 @@ namespace BGC.Tests
                 typedRoot.Child.Grandchild,
                 "A defaulted property group's own nested [AppendSelection] child must be " +
                 "recursively defaulted, not left null.");
+        }
+
+        // ---- Item-title defaulting -----------------------------------------------------------
+        // A group carrying [PropertyGroupItemTitle] that is default-constructed (absent key ->
+        // Internal_RawDeserialize(new JsonObject())) has no serialized title. That is a normal
+        // default, not an error: Serialize() always writes the title, so a title is only ever
+        // absent for default construction or for legacy data that predates the title field.
+
+        [PropertyGroupTitle("Titled Child")]
+        private interface ITitledChild : IPropertyGroup { }
+
+        [PropertyChoiceTitle("Default Titled Child")]
+        private class TitledChild : CommonPropertyGroup, ITitledChild
+        {
+            [PropertyGroupItemTitle("ItemTitle")]
+            public string ItemTitle { get; set; }
+        }
+
+        private class TitledRoot : CommonPropertyGroup
+        {
+            [AppendSelection(typeof(TitledChild))]
+            public ITitledChild Child { get; set; }
+        }
+
+        [Test]
+        public void AbsentTitledPropertyGroupKey_DefaultsWithoutLoggingError()
+        {
+            IPropertyGroup root = new TitledRoot();
+            root.InitializeProperties();
+
+            // "Child" key absent -> default-constructed from an empty object. The child carries
+            // a [PropertyGroupItemTitle], so its title is legitimately absent. There is no
+            // LogAssert.Expect here on purpose: before the fix this logged
+            // "No Item Title Found ... Creating Guid", which the Unity test runner reports as a
+            // failure (and which surfaced in researcher logs for every old battery that omitted
+            // a now-nested titled group).
+            root.Internal_RawDeserialize(new JsonObject());
+
+            TitledChild child = (TitledChild)((TitledRoot)root).Child;
+
+            Assert.IsNotNull(
+                child,
+                "An absent nested titled property group should be default-constructed.");
+            Assert.IsFalse(
+                string.IsNullOrEmpty(child.ItemTitle),
+                "A default-constructed titled group should still receive a generated item title.");
+
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }

--- a/Parameters/IPropertyGroup.cs
+++ b/Parameters/IPropertyGroup.cs
@@ -381,7 +381,18 @@ namespace BGC.Parameters
                 }
                 else
                 {
-                    Debug.LogError($"No Item Title Found with key: {serializationName}.  Creating Guid.");
+                    // Serialize() always writes the item title, so an absent title key means
+                    // either (a) real serialized data that predates the title field, or (b) a
+                    // group being default-constructed from an empty object -- the absent-key
+                    // path builds defaults via Internal_RawDeserialize(new JsonObject()). Only
+                    // (a) is anomalous; flagging (b) produced a false-positive error every time
+                    // an old battery omitted a now-nested titled group (and on every fresh
+                    // default construction of such a group). Suppress the error for the empty
+                    // (default-construction) case; still mint a Guid so list items stay unique.
+                    if (propertyGroupData.Count > 0)
+                    {
+                        Debug.LogError($"No Item Title Found with key: {serializationName}.  Creating Guid.");
+                    }
                     property.SetValue(container, Guid.NewGuid().ToString());
                 }
             }


### PR DESCRIPTION
## Summary

The absent-key deserialization path default-constructs a missing property group via `Internal_RawDeserialize(new JsonObject())` (added in #86, so a missing group's own nested children are recursively defaulted). When that default-constructed group carries a `[PropertyGroupItemTitle]`, deserializing an empty object reaches the "item title missing" branch and logs at **Error**:

```
No Item Title Found with key: ItemTitle.  Creating Guid.
```

This is a **false positive**. `Serialize()` always writes the item title, so a title key is only ever absent for:
- **(a)** real serialized data that predates the title field, or
- **(b)** a group being default-constructed from an empty object.

Case (b) is a normal default, not an error. It fires for **every old battery that omits a now-nested titled group** — e.g. the session-timer "None" option (`NullSessionTimedTaskProperties`) on the GoNoGo / CoreNBack / PuzzleNBack / PolyRules / RecollectSpan / EFMat task families and their gamified variants — and on every fresh default construction of such a group. It also fails any Unity test that exercises the path (e.g. PART's `BatteryStageSerializationRoundTripTests`, where 10 stages tripped it after the submodule was advanced to include #86).

## Fix

Only log when there is real serialized data (`propertyGroupData.Count > 0`). This preserves the diagnostic for genuinely title-less *stored* data while silencing the default-construction case. The `Guid` is still minted, so list-item identity behavior is unchanged.

Adds a regression test (`AbsentTitledPropertyGroupKey_DefaultsWithoutLoggingError`) alongside the existing #86 defaulting test: it default-constructs a titled group from an absent key and asserts no error is logged (`LogAssert.NoUnexpectedReceived()`).

## Validation

- `git diff` reviewed; change is a 1-line guard plus a comment, and one new test.
- ⚠️ **Not yet run in the Unity Test Runner in this environment** (no MCP/editor session available here). Please run `BGC.Tools` EditMode tests — specifically `PropertyGroupDefaultingTests` — to confirm green before merging.

## Notes for reviewers

- Logging-semantics change in shared lab infrastructure: the only behavioral change is that the missing-title `[Error]` is **no longer emitted for default construction**; it is unchanged for real stored data.
- Follow-up worth considering (not done here to keep the change minimal): the `Guid` minted for a default-constructed title is non-deterministic. It's a vestigial UI label on options like the session-timer "None", not a measurement, and it stabilizes after the first serialize — but if deterministic defaults are preferred, the empty-object case could assign `string.Empty` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)