### PR TITLE
QuestPlus: selection-entropy vector + likelihood-slice accessors for logging

### DIFF
--- a/Editor/Tests/Mathematics/QuestPlusTests.cs
+++ b/Editor/Tests/Mathematics/QuestPlusTests.cs
@@ -630,6 +630,70 @@ namespace BGC.Tests
 
         // ===== Helpers =====
 
+        // ===== Diagnostics accessors (logging support) =====
+
+        [Test]
+        public void LastExpectedEntropies_NullBeforeSelection_ThenMatchesChosen()
+        {
+            BGC.Mathematics.QuestPlus.QuestPlus q = BuildSimpleWeibull();
+
+            // No selection has run yet.
+            Assert.IsNull(q.LastExpectedEntropies);
+
+            double[] chosen = q.GetNextStimWithIndex(out int idx);
+            Assert.IsNotNull(q.LastExpectedEntropies);
+            Assert.AreEqual(q.StimSize, q.LastExpectedEntropies.Count,
+                "Expected-entropy vector should have one entry per candidate stimulus.");
+
+            // The chosen stimulus is the arg-min of the vector, and LastEntropy is that min.
+            double min = q.LastExpectedEntropies.Min();
+            Assert.AreEqual(min, q.LastExpectedEntropies[idx], 1e-12,
+                "Chosen stimulus should be the minimum-expected-entropy candidate.");
+            Assert.AreEqual(q.LastEntropy, q.LastExpectedEntropies[idx], 1e-12);
+            Assert.AreEqual(1, chosen.Length);
+
+            // Reset clears the retained vector.
+            q.Reset();
+            Assert.IsNull(q.LastExpectedEntropies);
+        }
+
+        [Test]
+        public void GetLikelihoodSlice_MatchesPsychometricEvaluate()
+        {
+            BGC.Mathematics.QuestPlus.QuestPlus q = BuildSimpleWeibull();
+            WeibullPsychometricFunction pf = new WeibullPsychometricFunction(WeibullScale.DB);
+
+            int[] shape = q.ParamDomain.Select(d => d.Length).ToArray();
+            double[] paramVals = new double[q.ParamDomain.Count];
+            double[] stimVals = new double[q.StimDomain.Count];
+            double[] probs = new double[q.OutcomeDomain.Count];
+
+            // Check a few stim points against every parameter cell, for each outcome.
+            foreach (int stimIdx in new[] { 0, q.StimSize / 2, q.StimSize - 1 })
+            {
+                stimVals[0] = q.StimDomain[0].Values[stimIdx]; // single stim dim
+                for (int outcome = 0; outcome < q.OutcomeCount; outcome++)
+                {
+                    double[] slice = q.GetLikelihoodSlice(stimIdx, outcome);
+                    Assert.AreEqual(q.ParamSize, slice.Length);
+
+                    for (int p = 0; p < q.ParamSize; p++)
+                    {
+                        // Decode flat param index (row-major, last dim fastest).
+                        int flat = p;
+                        for (int d = shape.Length - 1; d >= 0; d--)
+                        {
+                            paramVals[d] = q.ParamDomain[d].Values[flat % shape[d]];
+                            flat /= shape[d];
+                        }
+                        pf.Evaluate(stimVals, paramVals, probs);
+                        Assert.AreEqual(probs[outcome], slice[p], 1e-12,
+                            $"Likelihood slice mismatch at stim {stimIdx}, outcome {outcome}, param {p}.");
+                    }
+                }
+            }
+        }
+
         private static BGC.Mathematics.QuestPlus.QuestPlus BuildSimpleWeibull(
             ParamEstimationMethod estimation = ParamEstimationMethod.Mean,
             StimSelectionMethod selection = StimSelectionMethod.MinEntropy,

--- a/Mathematics/QuestPlus/IPsychometricFunction.cs
+++ b/Mathematics/QuestPlus/IPsychometricFunction.cs
@@ -63,4 +63,21 @@ namespace BGC.Mathematics.QuestPlus
         /// </summary>
         JsonObject SerializeConfig();
     }
+
+    /// <summary>
+    /// Optional add-on interface for psychometric functions that carry a revision
+    /// number. Logged into QUEST+ diagnostics so a change to a function's formula can
+    /// be detected by anyone comparing against an old log (an old log won't advertise
+    /// the new version). Kept separate from <see cref="IPsychometricFunction"/> so it
+    /// stays additive — existing functions need not implement it (consumers treat a
+    /// non-implementing function as version 0 / unversioned).
+    /// </summary>
+    public interface IVersionedPsychometricFunction
+    {
+        /// <summary>
+        /// Revision of this function's formula. Bump whenever the mathematical
+        /// definition changes so old logs are not silently misread as the new form.
+        /// </summary>
+        int FunctionVersion { get; }
+    }
 }

--- a/Mathematics/QuestPlus/PsychometricFunctions/TruncatedLogParabolaCsfPsychometricFunction.cs
+++ b/Mathematics/QuestPlus/PsychometricFunctions/TruncatedLogParabolaCsfPsychometricFunction.cs
@@ -43,9 +43,14 @@ namespace BGC.Mathematics.QuestPlus.PsychometricFunctions
     /// </code>
     /// </para>
     /// </summary>
-    public sealed class TruncatedLogParabolaCsfPsychometricFunction : IPsychometricFunction
+    public sealed class TruncatedLogParabolaCsfPsychometricFunction : IPsychometricFunction, IVersionedPsychometricFunction
     {
         public string TypeId => "truncated_log_parabola_csf";
+
+        // Revision of the formulas below. Bump if ComputeLogThresholdDb or Evaluate
+        // changes so QUEST+ logs record which form produced them (see QuestPlus_Verification.md).
+        public int FunctionVersion => 1;
+
         public int StimDimensionCount => 2;
         public int ParamDimensionCount => 7;
         public int OutcomeCount => 2;

--- a/Mathematics/QuestPlus/QuestPlus.cs
+++ b/Mathematics/QuestPlus/QuestPlus.cs
@@ -63,6 +63,16 @@ namespace BGC.Mathematics.QuestPlus
         /// <summary>Last computed expected entropy of the selected stimulus.</summary>
         public double LastEntropy { get; private set; } = double.NaN;
 
+        /// <summary>
+        /// The expected entropy computed for every candidate stimulus during the most
+        /// recent stimulus selection, in stim-domain flat-index order (length StimSize).
+        /// This is the full selection diagnostic: the chosen stimulus is the arg-min of
+        /// this vector (or, for MinNEntropy, a random draw among its N smallest entries).
+        /// Null before the first selection and after <see cref="Reset"/>. Not part of the
+        /// serialized state — it is regenerated on the next selection.
+        /// </summary>
+        public IReadOnlyList<double> LastExpectedEntropies => lastExpectedEntropies;
+
         // ---- Internals ----
 
         private readonly QuestPlusDimension[] stimDomain;
@@ -84,6 +94,10 @@ namespace BGC.Mathematics.QuestPlus
 
         private readonly List<TrialRecord> history = new List<TrialRecord>();
         private readonly Random rng;
+
+        // Expected entropy per candidate stimulus from the most recent selection
+        // (retained for diagnostics/logging; recomputed each GetNextStim* call).
+        private double[] lastExpectedEntropies;
 
         public int StimSize => stimSize;
         public int ParamSize => paramSize;
@@ -289,6 +303,7 @@ namespace BGC.Mathematics.QuestPlus
         public double[] GetNextStimWithIndex(out int stimFlatIndex)
         {
             double[] expectedEntropies = ComputeExpectedEntropies();
+            lastExpectedEntropies = expectedEntropies;
 
             switch (SelectionMethod)
             {
@@ -542,6 +557,35 @@ namespace BGC.Mathematics.QuestPlus
             return CoordsToIndex(coords, stimShape);
         }
 
+        /// <summary>
+        /// The likelihood of the given outcome across the whole parameter grid for a
+        /// fixed stimulus: <c>L(outcome | stim, θ)</c> for every θ, in parameter
+        /// flat-index order (length <see cref="ParamSize"/>). This is exactly the slice
+        /// the posterior is multiplied by in <see cref="UpdateByIndex"/>, exposed so an
+        /// independent implementation can check our psychometric-function evaluations
+        /// against its own. Values come straight from the precomputed likelihood table
+        /// (no recomputation), so they match what the engine actually used.
+        /// </summary>
+        public double[] GetLikelihoodSlice(int stimFlatIndex, int outcomeIndex)
+        {
+            if (stimFlatIndex < 0 || stimFlatIndex >= stimSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(stimFlatIndex));
+            }
+            if (outcomeIndex < 0 || outcomeIndex >= outcomeCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(outcomeIndex));
+            }
+
+            int baseIdx = (stimFlatIndex * paramSize) * outcomeCount;
+            double[] slice = new double[paramSize];
+            for (int p = 0; p < paramSize; p++)
+            {
+                slice[p] = likelihoods[baseIdx + p * outcomeCount + outcomeIndex];
+            }
+            return slice;
+        }
+
         // ---- Estimation ----
 
         /// <summary>
@@ -669,6 +713,7 @@ namespace BGC.Mathematics.QuestPlus
             Array.Copy(prior, posterior, paramSize);
             history.Clear();
             LastEntropy = double.NaN;
+            lastExpectedEntropies = null;
         }
 
         // ---- Serialization ----


### PR DESCRIPTION
## What

Two additive, backward-compatible accessors on the QUEST+ engine so host projects can log and **independently verify** QUEST+ internals per trial:

- **`LastExpectedEntropies`** — retains the per-candidate expected-entropy vector already computed inside `GetNextStimWithIndex` (it was being discarded). This is the full stimulus-selection diagnostic; the chosen stimulus is its arg-min. Cleared on `Reset()`.
- **`GetLikelihoodSlice(stimFlatIndex, outcomeIndex)`** — returns `L(outcome | stim, θ)` across the whole parameter grid, read straight from the precomputed likelihood table (the exact slice the posterior update uses).

Also adds an **optional** `IVersionedPsychometricFunction` and versions the truncated-log-parabola CSF function (`FunctionVersion = 1`), so a later formula change can't be silently misread against old logs.

## Why

Requested by researchers who are reproducing the PART CSF QUEST+ task in MATLAB/Python and need the logs to expose enough per-trial internal state to check the implementation (posterior/selection/likelihood), not just outcomes. The PART side consumes these to write rich per-trial + opt-in audit logs.

## Safety / compatibility

- **No behavior change.** The entropy vector is the one already computed; the slice accessor is read-only; the interface is opt-in (existing functions need not implement it and are treated as unversioned).
- Existing Watson golden-sequence tests are unaffected.
- Adds engine tests: `LastExpectedEntropies` matches the chosen arg-min / `LastEntropy` and clears on reset; `GetLikelihoodSlice` matches `PsychometricFunction.Evaluate` at sampled grid points across outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)